### PR TITLE
Prefer short circuit and membership test

### DIFF
--- a/src/apps/hac_pkg.adb
+++ b/src/apps/hac_pkg.adb
@@ -22,7 +22,7 @@ package body HAC_Pkg is
   begin
     for i in path'Range loop
       new_sep_pos := sep_pos;
-      if path (i) = ',' or else path (i) = ';' then
+      if path (i) in ',' | ';' then
         new_sep_pos := i;
       elsif i = path'Last then
         new_sep_pos := i + 1;

--- a/src/apps/hac_pkg.adb
+++ b/src/apps/hac_pkg.adb
@@ -22,7 +22,7 @@ package body HAC_Pkg is
   begin
     for i in path'Range loop
       new_sep_pos := sep_pos;
-      if path (i) = ',' or path (i) = ';' then
+      if path (i) = ',' or else path (i) = ';' then
         new_sep_pos := i;
       elsif i = path'Last then
         new_sep_pos := i + 1;

--- a/src/compile/hac_sys-builder.adb
+++ b/src/compile/hac_sys-builder.adb
@@ -108,11 +108,11 @@ package body HAC_Sys.Builder is
     end if;
     for round in Positive loop
       Compile_Pending_Bodies_Single_Round (BD, num_pending);
-      if num_pending > 0 and BD.CD.trace.detail_level >= 2 then
+      if num_pending > 0 and then BD.CD.trace.detail_level >= 2 then
         Compiler.Progress_Message
-          (BD.CD.all,
-           "--  Round" & Integer'Image (round) &
-           ", compiled bodies:" & Integer'Image (num_pending));
+         (BD.CD.all,
+          "--  Round" & Integer'Image (round) & ", compiled bodies:" &
+          Integer'Image (num_pending));
       end if;
       exit when num_pending = 0;
     end loop;

--- a/src/compile/hac_sys-multi_precision_integers.adb
+++ b/src/compile/hac_sys-multi_precision_integers.adb
@@ -315,12 +315,12 @@ package body HAC_Sys.Multi_Precision_Integers is
 
   function Even (i : Multi_int) return Boolean is
   begin
-    return i.zero or i.blk (0) mod 2 = 0;
+    return i.zero or else i.blk (0) mod 2 = 0;
   end Even;
 
   function Odd (i : Multi_int) return Boolean is
   begin
-    return (not i.zero) and i.blk (0) mod 2 = 1;
+    return (not i.zero) and then i.blk (0) mod 2 = 1;
   end Odd;
 
   ----------------------------
@@ -460,22 +460,22 @@ package body HAC_Sys.Multi_Precision_Integers is
     sgn : Boolean;
   begin
     --  (1) Les cas o\`u i1 ou i2 = 0
-    if i1.zero and i2.zero then
+    if i1.zero and then i2.zero then
       i3.zero := True;
     elsif i1.zero then
       Fill (i3, i2);
     elsif i2.zero then
       Fill (i3, i1);
-    --  (2) Maintenant: i1 /= 0 et i2 /= 0; on regarde les signes
-    --  (2.1) Facile: i1 et i2 de m\^eme signe
+      --  (2) Maintenant: i1 /= 0 et i2 /= 0; on regarde les signes
+      --  (2.1) Facile: i1 et i2 de m\^eme signe
     elsif i1.neg = i2.neg then
       Add_absolute (i1, i2, i3); -- On fait comme si i1>0 et i2>0
       i3.neg := i1.neg;           -- et on met le bon signe
-    --  (2.2) i1 < 0, i2 > 0, donc i3 = i2 - abs(i1)
-    elsif i1.neg and not i2.neg then
+      --  (2.2) i1 < 0, i2 > 0, donc i3 = i2 - abs(i1)
+    elsif i1.neg and then not i2.neg then
       Sub_absolute (i2, i1, i3, sgn);
-    --  (2.3) i1 > 0, i2 < 0, donc i3 = i1 - abs(i2)
-    elsif i2.neg and not i1.neg then
+      --  (2.3) i1 > 0, i2 < 0, donc i3 = i1 - abs(i2)
+    elsif i2.neg and then not i1.neg then
       Sub_absolute (i1, i2, i3, sgn);
     end if;
   end Add;
@@ -491,31 +491,35 @@ package body HAC_Sys.Multi_Precision_Integers is
     sgn : Boolean;
   begin
     --  (1) Les cas o\`u i1 ou i2 = 0
-    if    i1.zero and i2.zero then i3.zero := True;
-    elsif i1.zero then Fill (i3, i2); i3.neg := not i2.neg;
-    elsif i2.zero then Fill (i3, i1);
+    if i1.zero and then i2.zero then
+      i3.zero := True;
+    elsif i1.zero then
+      Fill (i3, i2);
+      i3.neg := not i2.neg;
+    elsif i2.zero then
+      Fill (i3, i1);
 
-    --  (2) Maintenant: i1 /= 0 et i2 /= 0; on regarde les signes
+      --  (2) Maintenant: i1 /= 0 et i2 /= 0; on regarde les signes
 
-    --  (2.1) Facile: i1 et i2 de m\^eme signe
+      --  (2.1) Facile: i1 et i2 de m\^eme signe
     elsif i1.neg = i2.neg then
       Sub_absolute (i1, i2, i3, sgn); -- On fait comme si i1>0 et i2>0
-                                      --  et on met le bon signe
-    i3.neg := i1.neg xor sgn;
-    --  26-Mar-2002: equivalent a:
-    --      if i1.neg then
-    --        i3.neg:= NOT sgn;
-    --      else
-    --        i3.neg:= sgn;
-    --      end if;
+      --  et on met le bon signe
+      i3.neg := i1.neg xor sgn;
+      --  26-Mar-2002: equivalent a:
+      --      if i1.neg then
+      --        i3.neg:= NOT sgn;
+      --      else
+      --        i3.neg:= sgn;
+      --      end if;
 
-    --  (2.2) i1 < 0, i2 > 0, donc i3 = i1-i2 = - (abs(i1) + abs(i2))
-    elsif i1.neg and not i2.neg then
+      --  (2.2) i1 < 0, i2 > 0, donc i3 = i1-i2 = - (abs(i1) + abs(i2))
+    elsif i1.neg and then not i2.neg then
       Add_absolute (i1, i2, i3);
       i3.neg := True;
 
-    --  (2.3) i1 > 0, i2 < 0, donc i3 = i1-i2 = i1 + (-i2) = i1 + abs(i2)
-    elsif i2.neg and not i1.neg then
+      --  (2.3) i1 > 0, i2 < 0, donc i3 = i1-i2 = i1 + (-i2) = i1 + abs(i2)
+    elsif i2.neg and then not i1.neg then
       Add_absolute (i1, i2, i3);
     end if;
 
@@ -570,7 +574,7 @@ package body HAC_Sys.Multi_Precision_Integers is
     --  res: buffer used in the "copy" variant to avoid
     --  problems with Multiply(i,j,i) or Multiply(j,i,i)
   begin
-    if i1.zero or i2.zero then
+    if i1.zero or else i2.zero then
       i3.zero := True;
       return;
     end if;
@@ -661,7 +665,7 @@ package body HAC_Sys.Multi_Precision_Integers is
     --  res: buffer used in the "copy" variant to avoid
     --  problems with Multiply(i,j,i) or Multiply(j,i,i)
   begin
-    if i1.zero or i2 = 0 then
+    if i1.zero or else i2 = 0 then
       i3.zero := True;
       return;
     end if;
@@ -768,7 +772,7 @@ package body HAC_Sys.Multi_Precision_Integers is
 
   function "*" (i1, i2 : Multi_int) return Multi_int is
   begin
-    if i1.zero or i2.zero then
+    if i1.zero or else i2.zero then
       return zero;
     else
       declare
@@ -782,7 +786,7 @@ package body HAC_Sys.Multi_Precision_Integers is
 
   function "*" (i1 : Multi_int; i2 : Basic_Int) return Multi_int is
   begin
-    if i1.zero or i2 = 0 then
+    if i1.zero or else i2 = 0 then
       return zero;
     else
       declare
@@ -796,7 +800,7 @@ package body HAC_Sys.Multi_Precision_Integers is
 
   function "*" (i1 : Basic_Int; i2 : Multi_int) return Multi_int is
   begin
-    if i2.zero or i1 = 0 then
+    if i2.zero or else i1 = 0 then
       return zero;
     else
       declare
@@ -983,18 +987,18 @@ package body HAC_Sys.Multi_Precision_Integers is
   begin
     --  Invariant: i1= i2*q+r   on cherche (pos) = (pos)*(pos)+(pos)
 
-    if i1n and i2n then        -- i1<0;  i2<0  (-i1) = (-i2) *  q  + (-r)
+    if i1n and then i2n then        -- i1<0;  i2<0  (-i1) = (-i2) *  q  + (-r)
       qn := False; -- Quotient > 0
-    --      rn:= True;  -- Reste    < 0
+      --      rn:= True;  -- Reste    < 0
     elsif i1n then             -- i1<0;  i2>0  (-i1) =   i2  *(-q) + (-r)
       qn := True;  -- Quotient < 0
-    --      rn:= True;  -- Reste    < 0
+      --      rn:= True;  -- Reste    < 0
     elsif i2n then             -- i1>0;  i2<0    i1  = (-i2) *(-q) +   r
       qn := True;  -- Quotient < 0
-    --      rn:= False; -- Reste    > 0
+      --      rn:= False; -- Reste    > 0
     else                       -- i1>0;  i2>0    i1  =   i2  *  q  +   r
       qn := False; -- Quotient > 0
-    --      rn:= False; -- Reste    > 0
+      --      rn:= False; -- Reste    > 0
     end if;
     --  on observe que... "(A rem B) has the sign of A " ARM 4.5.5
     --  en effet on peut mettre:
@@ -1392,7 +1396,7 @@ package body HAC_Sys.Multi_Precision_Integers is
      raise Power_negative;
     end if;
 
-    if modulo.zero or else (i.neg or modulo.neg) then
+    if modulo.zero or else (i.neg or else modulo.neg) then
       raise Power_modulo_non_positive;
     end if;
 
@@ -1459,24 +1463,33 @@ package body HAC_Sys.Multi_Precision_Integers is
   function ">" (i1, i2 : Multi_int) return Boolean is
   begin
     --  (1) Cas \'evident o\`u:         i1 <= i2
-    if (i1.zero or i1.neg) and then             -- i1 <= 0 et
-       (i2.zero or not i2.neg)                  -- i2 >= 0
+    if
+     (i1.zero
+      or else i1.neg) and then             -- i1 <= 0 et
+
+     (i2.zero or else not i2.neg)                  -- i2 >= 0
     then
-        return False;
+      return False;
     end if;
 
     --  (2.1) Cas \'evident o\`u:       i1 > i2
-    if ((not i1.zero) and not i1.neg) and then  -- i1 > 0 et
-       (i2.zero or i2.neg)                      -- i2 <= 0
+    if
+     ((not i1.zero)
+      and then not i1.neg) and then  -- i1 > 0 et
+
+     (i2.zero or else i2.neg)                      -- i2 <= 0
     then
-        return True;
+      return True;
     end if;
 
     --  (2.2) Cas \'evident o\`u:       i1 > i2
-    if (i1.zero or not i1.neg) and then         -- i1 >= 0 et
-       ((not i2.zero) and i2.neg)               -- i2 < 0
+    if
+     (i1.zero
+      or else not i1.neg) and then         -- i1 >= 0 et
+
+     ((not i2.zero) and then i2.neg)               -- i2 < 0
     then
-        return True;
+      return True;
     end if;
 
     --  Cas faciles resolus:

--- a/src/compile/hac_sys-parser-const_var.adb
+++ b/src/compile/hac_sys-parser-const_var.adb
@@ -133,7 +133,7 @@ package body HAC_Sys.Parser.Const_Var is
         CD.Sy := Becomes;
       end if;
       --
-      is_untyped_constant := is_constant and not is_typed;
+      is_untyped_constant := is_constant and then not is_typed;
       --
       if is_untyped_constant then
         --  Numeric constant: we parse the number here ("k : constant := 123.0").
@@ -146,7 +146,8 @@ package body HAC_Sys.Parser.Const_Var is
       end if;
       --
       T0i := T0;
-      if is_constant or is_typed then  --  All correct cases: untyped variables were caught.
+      if is_constant or else is_typed
+      then  --  All correct cases: untyped variables were caught.
         --  Update identifier table
         while T0 < T1 loop
           T0 := T0 + 1;
@@ -155,7 +156,8 @@ package body HAC_Sys.Parser.Const_Var is
           begin
             r.read_only := is_constant;
             if is_untyped_constant then
-              r.entity := Declared_Number_or_Enum_Item;  --  r was initially a Variable.
+              r.entity :=
+               Declared_Number_or_Enum_Item;  --  r was initially a Variable.
               r.xtyp := C.TP;
               case C.TP.TYP is
                 when Floats =>
@@ -168,19 +170,20 @@ package body HAC_Sys.Parser.Const_Var is
                   r.adr_or_sz := Integer (C.I);
               end case;
             else  --  A variable or a typed constant
-              r.xtyp      := xTyp;
+              r.xtyp                           := xTyp;
               r.adr_or_sz := Block_Data.data_allocation_index;
-              Block_Data.data_allocation_index := Block_Data.data_allocation_index + Sz;
+              Block_Data.data_allocation_index :=
+               Block_Data.data_allocation_index + Sz;
             end if;
           end;
         end loop;  --  While T0 < T1
       end if;
       --
-      if CD.Sy = EQL and not is_untyped_constant then
+      if CD.Sy = EQL and then not is_untyped_constant then
         Error (CD, err_EQUALS_instead_of_BECOMES);
         CD.Sy := Becomes;
       end if;
-      if is_constant and is_typed then
+      if is_constant and then is_typed then
         --  For typed constants, the ":=" is required and consumed with the Assignment below.
         Test (CD, Becomes_Set, empty_symset, err_BECOMES_missing);
       end if;

--- a/src/compile/hac_sys-parser-enter_def.adb
+++ b/src/compile/hac_sys-parser-enter_def.adb
@@ -115,13 +115,12 @@ package body HAC_Sys.Parser.Enter_Def is
          err_illegal_array_bounds, "Low > High. NB: legal in Ada (empty array)", -- !!
          severity => major);
     end if;
-    if   Index_STP.Discrete_First < -HAC_Integer (XMax)
-      or Index_STP.Discrete_Last  >  HAC_Integer (XMax)
+    if Index_STP.Discrete_First < -HAC_Integer (XMax)
+     or else Index_STP.Discrete_Last > HAC_Integer (XMax)
     then
       Error
-        (CD,
-         err_illegal_array_bounds, "absolute value of a bound exceeds maximum value",
-         severity => major);
+       (CD, err_illegal_array_bounds,
+        "absolute value of a bound exceeds maximum value", severity => major);
     end if;
     if CD.Arrays_Count = AMax then
       Fatal (ARRAYS);  --  Exception is raised there.

--- a/src/compile/hac_sys-parser-expressions.adb
+++ b/src/compile/hac_sys-parser-expressions.adb
@@ -141,8 +141,9 @@ package body HAC_Sys.Parser.Expressions is
             else
               if Ranges.Do_Ranges_Overlap (Array_Index_Typ,  ATE.Index_xTyp) then
                 range_check_needed :=
-                     Array_Index_Typ.Discrete_First < ATE.Index_xTyp.Discrete_First
-                  or Array_Index_Typ.Discrete_Last  > ATE.Index_xTyp.Discrete_Last;
+                 Array_Index_Typ.Discrete_First < ATE.Index_xTyp.Discrete_First
+                 or else Array_Index_Typ.Discrete_Last >
+                  ATE.Index_xTyp.Discrete_Last;
                 --
                 if ATE.Element_Size = 1 then
                   if range_check_needed then
@@ -281,11 +282,13 @@ package body HAC_Sys.Parser.Expressions is
           Rel_OP := CD.Sy;
           InSymbol (CD);
           Simple_Expression (CD, Level, FSys_Rel, Y);
-          if Internally_VString_Set (X.TYP) and Internally_VString_Set (Y.TYP) then
+          if Internally_VString_Set (X.TYP)
+           and then Internally_VString_Set (Y.TYP)
+          then
             --  The internal type is actually a VString on both sides.
             Emit_Comparison_Instruction (CD, Rel_OP, VStrings);
           elsif X.TYP = Y.TYP then
-            if X.TYP = Enums and X.Ref /= Y.Ref then
+            if X.TYP = Enums and then X.Ref /= Y.Ref then
               Issue_Comparison_Type_Mismatch_Error;
             elsif PCode_Atomic_Typ (X.TYP) then
               Emit_Comparison_Instruction (CD, Rel_OP, X.TYP);
@@ -297,18 +300,21 @@ package body HAC_Sys.Parser.Expressions is
             --  since it takes two elements on the stack.
             Emit_Std_Funct (CD, SF_Literal_to_VString);
             Emit (CD, k_Swap);
-            Emit_Std_Funct (CD,
-              SF_String_to_VString,
-              Operand_1_Type (CD.Arrays_Table (X.Ref).Array_Size)
-            );
+            Emit_Std_Funct
+             (CD, SF_String_to_VString,
+              Operand_1_Type (CD.Arrays_Table (X.Ref).Array_Size));
             Emit (CD, k_Swap);
             Emit_Comparison_Instruction (CD, Rel_OP, VStrings);
-          elsif Internally_VString_Set (X.TYP) and Y.TYP = String_Literals then  --  E.g., X < "World"
+          elsif Internally_VString_Set (X.TYP) and Y.TYP = String_Literals
+          then  --  E.g., X < "World"
             --  Y is on top of the stack, we turn it into a VString.
             --  If this becomes a perfomance issue we could consider
             --  a new Standard Function (SF_Code) for (VStr op Lit_Str).
-            Emit_Std_Funct (CD, SF_Literal_to_VString);            --  Now we have X < +"World".
-            Emit_Comparison_Instruction (CD, Rel_OP, VStrings);    --  Emit "<" (X, +Y).
+            Emit_Std_Funct
+             (CD,
+              SF_Literal_to_VString);            --  Now we have X < +"World".
+            Emit_Comparison_Instruction
+             (CD, Rel_OP, VStrings);    --  Emit "<" (X, +Y).
           elsif X.TYP = Ints and Y.TYP = Floats then
             Forbid_Type_Coercion (CD, Rel_OP, X, Y);
             X.TYP := Floats;
@@ -717,7 +723,9 @@ package body HAC_Sys.Parser.Expressions is
       if X.TYP /= VStrings and y.TYP /= VStrings then
         return False;
         --  Below this line, at least X or Y is a VString.
-      elsif Internally_VString_Set (X.TYP) and Internally_VString_Set (y.TYP) then
+      elsif Internally_VString_Set (X.TYP)
+       and then Internally_VString_Set (y.TYP)
+      then
         --  v1 & v2              A.4.5 (15)
         --  v & Enum'Image (x)   A.4.5 (16),
         --  Enum'Image (x) & v   A.4.5 (17)

--- a/src/compile/hac_sys-parser-helpers.adb
+++ b/src/compile/hac_sys-parser-helpers.adb
@@ -379,7 +379,7 @@ package body HAC_Sys.Parser.Helpers is
       );
     elsif X.TYP = VStrings or X.TYP = Strings_as_VStrings then
       null;  --  Already a VString.
-    elsif X.TYP = Chars and include_characters then
+    elsif X.TYP = Chars and then include_characters then
       Emit_Std_Funct (CD, SF_Char_to_VString);
     else
       Type_Mismatch (
@@ -470,7 +470,7 @@ package body HAC_Sys.Parser.Helpers is
         J := CD.IdTab (J).link;  --  Skip this identifier.
       end loop;
       L := L - 1;  --  Decrease nesting level.
-      exit when L < 0 or J /= No_Id;
+      exit when L < 0 or else J /= No_Id;
     end loop;
     if J = No_Id then
       if not Fail_when_No_Id then

--- a/src/compile/hac_sys-parser-packages.adb
+++ b/src/compile/hac_sys-parser-packages.adb
@@ -115,7 +115,7 @@ package body HAC_Sys.Parser.Packages is
           --  in that package are checked anyway.
           Package_Declaration (CD, FSys, block_data, subpkg_needs_body);
           Need_Semicolon_after_Declaration (CD, FSys);
-          needs_body := needs_body or subpkg_needs_body;
+          needs_body := needs_body or else subpkg_needs_body;
           Mark_Last_Declaration;
         when PRIVATE_Symbol =>
           Scanner.InSymbol (CD);

--- a/src/compile/hac_sys-parser-ranges.adb
+++ b/src/compile/hac_sys-parser-ranges.adb
@@ -232,7 +232,7 @@ package body HAC_Sys.Parser.Ranges is
   function Do_Ranges_Overlap (X_min, X_max, Y_min, Y_max : Defs.HAC_Integer) return Boolean is
     use type Defs.HAC_Integer;
   begin
-    pragma Assert (X_min <= X_max and Y_min <= Y_max);
+    pragma Assert (X_min <= X_max and then Y_min <= Y_max);
     --
     --  The following is logically identical to: "not (Y_max < X_min or X_max < Y_min)",
     --  which means we don't have this situation:

--- a/src/compile/hac_sys-parser-statements.adb
+++ b/src/compile/hac_sys-parser-statements.adb
@@ -172,7 +172,7 @@ package body HAC_Sys.Parser.Statements is
     else
       loop
         Statement (CD, statement_or_sentinel, Block_Data);
-        exit when Sentinel (CD.Sy) or CD.error_count > 0;
+        exit when Sentinel (CD.Sy) or else CD.error_count > 0;
       end loop;
     end if;
   end Sequence_of_Statements;

--- a/src/compile/hac_sys-parser-tasking.adb
+++ b/src/compile/hac_sys-parser-tasking.adb
@@ -98,7 +98,7 @@ package body HAC_Sys.Parser.Tasking is
 
         Level := Level - 1;
         Need_END_Symbol (CD);
-        if CD.Sy = IDent and CD.Id = TaskID then
+        if CD.Sy = IDent and then CD.Id = TaskID then
           InSymbol;
         else
           Error_then_Skip (CD, Semicolon, err_incorrect_name_after_END);

--- a/src/compile/hac_sys-parser.adb
+++ b/src/compile/hac_sys-parser.adb
@@ -317,7 +317,7 @@ package body HAC_Sys.Parser is
         return;
       end if;
       --
-      if CD.Sy = NULL_Symbol and not Is_a_block_statement then
+      if CD.Sy = NULL_Symbol and then not Is_a_block_statement then
         --  RM 6.7 Null Procedures (Ada 2005)
         --  E.g.: "procedure Not_Yet_Done (a : Integer) is null;"
         InSymbol;  --  Consume NULL symbol.
@@ -345,11 +345,14 @@ package body HAC_Sys.Parser is
           return;
         end if;
         --
-        if CD.Sy = IDent then  --  Verify that the name after "end" matches the unit name.
+        if CD.Sy = IDent
+        then  --  Verify that the name after "end" matches the unit name.
           Check_ident_after_END;
-        elsif Is_a_block_statement and Block_Id /= Empty_Alfa then
+        elsif Is_a_block_statement and then Block_Id /= Empty_Alfa then
           --  No identifier after "end", but "end [label]" is required in this case.
-          Error (CD, err_incorrect_name_after_END, hint_1 => A2S (Block_Id_with_case));
+          Error
+           (CD, err_incorrect_name_after_END,
+            hint_1 => A2S (Block_Id_with_case));
         end if;
       end if;
       --
@@ -358,9 +361,9 @@ package body HAC_Sys.Parser is
         return;
       end if;
       --
-      if block_data.level <= 1 or Is_a_block_statement then
+      if block_data.level <= 1 or else Is_a_block_statement then
         --  Time to count the minor errors as errors.
-        CD.error_count := CD.error_count + CD.minor_error_count;
+        CD.error_count       := CD.error_count + CD.minor_error_count;
         CD.minor_error_count := 0;
       else
         InSymbol;  --  Consume ';' symbol after END [Subprogram_Id].
@@ -368,11 +371,9 @@ package body HAC_Sys.Parser is
         --
         --  Now we have either another declaration,
         --  or BEGIN or, if it's a package, END  .
-        Test (
-          CD, FSys + Declaration_Symbol + BEGIN_Symbol + END_Symbol,
-          empty_symset,
-          err_incorrectly_used_symbol
-        );
+        Test
+         (CD, FSys + Declaration_Symbol + BEGIN_Symbol + END_Symbol,
+          empty_symset, err_incorrectly_used_symbol);
       end if;
     end Process_Body;
 
@@ -413,7 +414,7 @@ package body HAC_Sys.Parser is
     CD.Blocks_Table (subprogram_block_index).Last_Param_Id_Idx := CD.Id_Count;
     CD.Blocks_Table (subprogram_block_index).PSize := block_data.data_allocation_index;
     --
-    if block_data.entity = Funktion and not Is_a_block_statement then
+    if block_data.entity = Funktion and then not Is_a_block_statement then
       Function_Result_Profile;
     end if;
     --

--- a/src/compile/hac_sys-scanner.adb
+++ b/src/compile/hac_sys-scanner.adb
@@ -295,20 +295,20 @@ package body HAC_Sys.Scanner is
         l := l + 1;
         s (l) := CD.CUD.c;
         exit when CD.CUD.c = '#';  --  Second '#'.
-        has_point := has_point or CD.CUD.c = '.';
+        has_point := has_point or else CD.CUD.c = '.';
       end loop;
       NextCh (CD);
-      if CD.CUD.c = 'E' or CD.CUD.c = 'e' then
+      if CD.CUD.c = 'E' or else CD.CUD.c = 'e' then
         --  Exponent. Special case because of eventual '+' or '-' which
         --  are not operators (e.g. 8#123#e+5 vs. 8#123#+5, = 8#123# + 5)...
         --  Otherwise we could have done it all in the previous loop.
         for c in 1 .. 2 loop
-          l := l + 1;
+          l     := l + 1;
           s (l) := CD.CUD.c;  --  We concatenate "e+", "e-", "e5".
           NextCh (CD);
         end loop;
         while CD.CUD.c in '0' .. '9' loop
-          l := l + 1;
+          l     := l + 1;
           s (l) := CD.CUD.c;  --  We concatenate the rest of the exponent.
           NextCh (CD);
         end loop;
@@ -364,7 +364,7 @@ package body HAC_Sys.Scanner is
         if e = 0 then
           Error (CD, err_illegal_character_in_number, "; expected digit after '.'");
         end if;
-        if CD.CUD.c = 'E' or CD.CUD.c = 'e' then
+        if CD.CUD.c = 'E' or else CD.CUD.c = 'e' then
           Read_Scale (True);
         end if;
         if e /= 0 then
@@ -454,7 +454,7 @@ package body HAC_Sys.Scanner is
       --  We peek the next character without moving.
       --  Possible since CD.CC < CD.LL .
       C2 := CD.CUD.input_line (CD.CUD.CC + 1);
-      if C1 = ''' and C2 /= ''' then  --  Case (6)
+      if C1 = ''' and then C2 /= ''' then  --  Case (6)
         Error (CD, err_character_zero_chars, severity => major);
       end if;
       --  Until now, case (5) to (9) are treated.

--- a/src/compile/hac_sys-scanner.adb
+++ b/src/compile/hac_sys-scanner.adb
@@ -298,7 +298,7 @@ package body HAC_Sys.Scanner is
         has_point := has_point or else CD.CUD.c = '.';
       end loop;
       NextCh (CD);
-      if CD.CUD.c = 'E' or else CD.CUD.c = 'e' then
+      if CD.CUD.c in 'E' | 'e' then
         --  Exponent. Special case because of eventual '+' or '-' which
         --  are not operators (e.g. 8#123#e+5 vs. 8#123#+5, = 8#123# + 5)...
         --  Otherwise we could have done it all in the previous loop.
@@ -364,7 +364,7 @@ package body HAC_Sys.Scanner is
         if e = 0 then
           Error (CD, err_illegal_character_in_number, "; expected digit after '.'");
         end if;
-        if CD.CUD.c = 'E' or else CD.CUD.c = 'e' then
+        if CD.CUD.c in 'E' | 'e' then
           Read_Scale (True);
         end if;
         if e /= 0 then

--- a/src/execute/hac_sys-pcode-interpreter-calls.adb
+++ b/src/execute/hac_sys-pcode-interpreter-calls.adb
@@ -157,8 +157,11 @@ package body HAC_Sys.PCode.Interpreter.Calls is
           Tasking.Queue (CD, ND, Ident_Index_of_Called, ND.CurTask);  --  put self on entry queue
           Curr_TCB.TS  := WaitRendzv;
           Task_Entered := CD.IdTab (Ident_Index_of_Called).adr_or_sz;  --  Task being entered
-          if ((ND.TCB (Task_Entered).TS = WaitRendzv) and (ND.TCB (Task_Entered).SUSPEND = Ident_Index_of_Called)) or
-             (ND.TCB (Task_Entered).TS = TimedWait)
+          if
+           ((ND.TCB (Task_Entered).TS = WaitRendzv)
+            and then
+            (ND.TCB (Task_Entered).SUSPEND = Ident_Index_of_Called)) or
+           (ND.TCB (Task_Entered).TS = TimedWait)
           then
             --  wake accepting task if necessary
             ND.TCB (Task_Entered).TS      := Ready;
@@ -170,33 +173,45 @@ package body HAC_Sys.PCode.Interpreter.Calls is
           Tasking.Queue (CD, ND, Ident_Index_of_Called, ND.CurTask);  --  put self on entry queue
           Task_Entered := CD.IdTab (Ident_Index_of_Called).adr_or_sz;  --  Task being entered
           --
-          if ((ND.TCB (Task_Entered).TS = WaitRendzv) and (ND.TCB (Task_Entered).SUSPEND = Ident_Index_of_Called)) or
-             (ND.TCB (Task_Entered).TS = TimedWait)
+          if
+           ((ND.TCB (Task_Entered).TS = WaitRendzv)
+            and then
+            (ND.TCB (Task_Entered).SUSPEND = Ident_Index_of_Called)) or
+           (ND.TCB (Task_Entered).TS = TimedWait)
           then
             --  wake accepting task if necessary
-            Curr_TCB.TS := WaitRendzv;     --  suspend self
+            Curr_TCB.TS                   := WaitRendzv;     --  suspend self
             ND.TCB (Task_Entered).TS := Ready;       --  wake accepting task
             ND.TCB (Task_Entered).SUSPEND := 0;
           else
-            Curr_TCB.TS := TimedRendz;          --  Timed Wait For Rendezvous
-            Curr_TCB.R1.I := 1;                 --  Init R1 to specify NO timeout
-            Curr_TCB.R2.I := HAC_Integer (Ident_Index_of_Called);  --  Save address of queue for purge
-            ND.SYSCLOCK := Clock;               --  update System Clock
+            Curr_TCB.TS   := TimedRendz;          --  Timed Wait For Rendezvous
+            Curr_TCB.R1.I :=
+             1;                 --  Init R1 to specify NO timeout
+            Curr_TCB.R2.I :=
+             HAC_Integer
+              (Ident_Index_of_Called);  --  Save address of queue for purge
+            ND.SYSCLOCK       := Clock;               --  update System Clock
             Curr_TCB.WAKETIME := ND.SYSCLOCK + Duration (F1);
           end if;
           ND.SWITCH := True;       --  give up control
 
         when Defs.Conditional_Entry_Call =>
           Task_Entered := CD.IdTab (Ident_Index_of_Called).adr_or_sz;              --  Task being entered
-          if ((ND.TCB (Task_Entered).TS = WaitRendzv) and (ND.TCB (Task_Entered).SUSPEND = Ident_Index_of_Called)) or
-             (ND.TCB (Task_Entered).TS = TimedWait)
+          if
+           ((ND.TCB (Task_Entered).TS = WaitRendzv)
+            and then
+            (ND.TCB (Task_Entered).SUSPEND = Ident_Index_of_Called)) or
+           (ND.TCB (Task_Entered).TS = TimedWait)
           then
-            Tasking.Queue (CD, ND, Ident_Index_of_Called, ND.CurTask);  --  put self on entry queue
-            Curr_TCB.R1.I := 1;        --  Indicate entry successful
-            Curr_TCB.TS := WaitRendzv;
-            ND.TCB (Task_Entered).TS      := Ready;  --  wake accepting task if required
+            Tasking.Queue
+             (CD, ND, Ident_Index_of_Called,
+              ND.CurTask);  --  put self on entry queue
+            Curr_TCB.R1.I            := 1;        --  Indicate entry successful
+            Curr_TCB.TS              := WaitRendzv;
+            ND.TCB (Task_Entered).TS :=
+             Ready;  --  wake accepting task if required
             ND.TCB (Task_Entered).SUSPEND := 0;
-            ND.SWITCH              := True;   --  give up control
+            ND.SWITCH                     := True;   --  give up control
           else
             --  can't wait, forget about entry call
             Curr_TCB.R1.I := 0;   --  Indicate entry failed in R1 1
@@ -223,14 +238,17 @@ package body HAC_Sys.PCode.Interpreter.Calls is
       else
         --  Set back base of caller:
         Curr_TCB.B := Integer (ND.S (Curr_TCB.B + 3).I);
-        if IR.Y = Defs.Timed_Entry_Call or IR.Y = Defs.Conditional_Entry_Call then
-          if IR.Y = Defs.Timed_Entry_Call and Curr_TCB.R1.I = 0 then
+        if IR.Y = Defs.Timed_Entry_Call
+         or else IR.Y = Defs.Conditional_Entry_Call
+        then
+          if IR.Y = Defs.Timed_Entry_Call and then Curr_TCB.R1.I = 0 then
             Push (ND);
           end if;
           --  A JMPC instruction always follows (?)
           --  timed and conditional entry call
           --  returns (32).  Push entry call
-          ND.S (Curr_TCB.T).I := Curr_TCB.R1.I;    --  success indicator for JMPC.
+          ND.S (Curr_TCB.T).I :=
+           Curr_TCB.R1.I;    --  success indicator for JMPC.
         end if;
       end if;
     end Do_Exit_Call;

--- a/src/execute/hac_sys-pcode-interpreter-tasking-scheduler.adb
+++ b/src/execute/hac_sys-pcode-interpreter-tasking-scheduler.adb
@@ -232,7 +232,9 @@ procedure Scheduler (CD : Compiler_Data; ND : in out Interpreter_Data) is
   begin
     t := 0;
     for i in 0 .. TCount loop
-      if ND.TCB (i).TS = Ready and ND.TCB (i).Pcontrol.UPRI > ND.TCB (t).Pcontrol.UPRI then
+      if ND.TCB (i).TS = Ready
+       and then ND.TCB (i).Pcontrol.UPRI > ND.TCB (t).Pcontrol.UPRI
+      then
         t := i;
       end if;
     end loop;

--- a/src/execute/hac_sys-pcode-interpreter-tasking.adb
+++ b/src/execute/hac_sys-pcode-interpreter-tasking.adb
@@ -20,7 +20,7 @@ package body HAC_Sys.PCode.Interpreter.Tasking is
   begin
     e := -1;
     i := 1;
-    while i <= CD.Entries_Count and e = -1 loop
+    while i <= CD.Entries_Count and then e = -1 loop
       if Entry_Index = CD.Entries_Table (i) then
         e := i;
       end if;
@@ -182,7 +182,9 @@ package body HAC_Sys.PCode.Interpreter.Tasking is
           end if;
           --  AVL -- TERMINATE
           --  IS THE PARENT TASK COMPLETED?
-          if ND.TCB (0).TS = Completed and ND.CurTask /= 0 and IR.X /= 6 then
+          if ND.TCB (0).TS = Completed and then ND.CurTask /= 0
+           and then IR.X /= 6
+          then
             ND.Nb_Callers := 0; --  LET'S SEE IF THERE ARE CALLERS
             for ITERM in 1 .. CD.Entries_Count loop
               if ND.EList (ITERM).First /= null then
@@ -201,9 +203,7 @@ package body HAC_Sys.PCode.Interpreter.Tasking is
                   if ND.TCB (ITERM).TS = Curr_TCB.TS then
                     ND.Nb_Complete := ND.Nb_Complete + 1;
                   else
-                    if ND.TCB (ITERM).TS = Ready and
-                      Curr_TCB.TS = Running
-                    then
+                    if ND.TCB (ITERM).TS = Ready and Curr_TCB.TS = Running then
                       ND.Nb_Complete := ND.Nb_Complete + 1;
                     end if;
                   end if;
@@ -238,12 +238,13 @@ package body HAC_Sys.PCode.Interpreter.Tasking is
       Pop (ND);
       H2 := CD.Tasks_Definitions_Count + 1;
       H3 := Integer (Random (ND.Gen) * Float (H2));
-      while H2 >= 0 and ND.TCB (H3).TS /= WaitSem and ND.TCB (H3).SUSPEND /= H1
+      while H2 >= 0 and ND.TCB (H3).TS /= WaitSem
+       and then ND.TCB (H3).SUSPEND /= H1
       loop
         H3 := (H3 + 1) mod (Defs.TaskMax + 1);
         H2 := H2 - 1;
       end loop;
-      if H2 < 0 or ND.S (H1).I < 0 then
+      if H2 < 0 or else ND.S (H1).I < 0 then
         ND.S (H1).I := ND.S (H1).I + 1;
       else
         ND.TCB (H3).SUSPEND := 0;
@@ -493,11 +494,10 @@ package body HAC_Sys.PCode.Interpreter.Tasking is
     use type Ada.Calendar.Time;
   begin
     for t in 0 .. CD.Tasks_Definitions_Count loop
-      if (ND.TCB (t).TS = Delayed or
-          ND.TCB (t).TS = TimedRendz or
-          ND.TCB (t).TS = TimedWait)
-        and
-          ND.SYSCLOCK >= ND.TCB (t).WAKETIME
+      if
+       (ND.TCB (t).TS = Delayed or ND.TCB (t).TS = TimedRendz or
+        ND.TCB (t).TS = TimedWait)
+       and then ND.SYSCLOCK >= ND.TCB (t).WAKETIME
       then
         if ND.TCB (t).TS = TimedRendz then
           ND.TCB (t).R1.I := 0; --  timeout on rendezvous
@@ -507,7 +507,7 @@ package body HAC_Sys.PCode.Interpreter.Tasking is
           ND.TCB (t).PC := Defs.Index (ND.TCB (t).R1.I); --  t.out on accept
         end if;
         ND.TCB (t).TS := Ready;
-        count := count + 1;
+        count         := count + 1;
       end if;
     end loop;
     Result := count > 0;
@@ -532,9 +532,8 @@ package body HAC_Sys.PCode.Interpreter.Tasking is
       end if;
     else
       Wake_Tasks (CD, ND, were_tasks_awakened);
-      if ND.SWITCH or       --  ------------> Voluntary release of control
-         ND.SYSCLOCK >= ND.TIMER or   --  ---> Time slice exceeded
-         were_tasks_awakened      --  ------> Awakened task causes switch
+      if ND.SWITCH or else ND.SYSCLOCK >= ND.TIMER
+       or else were_tasks_awakened      --  ------> Awakened task causes switch
       then
         if ND.CurTask >= 0 then
           ND.TCB (ND.CurTask).LASTRUN := ND.SYSCLOCK;
@@ -559,9 +558,9 @@ package body HAC_Sys.PCode.Interpreter.Tasking is
           return;
         end if;
         --
-        ND.TIMER := ND.SYSCLOCK + ND.TCB (ND.CurTask).QUANTUM;
+        ND.TIMER               := ND.SYSCLOCK + ND.TCB (ND.CurTask).QUANTUM;
         ND.TCB (ND.CurTask).TS := Running;
-        ND.SWITCH := False;
+        ND.SWITCH              := False;
         if ND.Snap then
           SnapShot;
         end if;

--- a/src/execute/hac_sys-pcode.adb
+++ b/src/execute/hac_sys-pcode.adb
@@ -105,8 +105,8 @@ package body HAC_Sys.PCode is
         (prev_old_value, prev_new_value : Opcode) is
       pragma Inline (Simple_Substitution);
       begin
-        if (not folded) and old.F = prev_old_value then
-          old.F := prev_new_value;
+        if (not folded) and then old.F = prev_old_value then
+          old.F  := prev_new_value;
           folded := True;
         end if;
       end Simple_Substitution;

--- a/src/manage/hac_sys-librarian.adb
+++ b/src/manage/hac_sys-librarian.adb
@@ -257,13 +257,9 @@ package body HAC_Sys.Librarian is
          severity => major);
     elsif Upper_Name = HAT_Name then
       Built_In_Packages.Define_and_Register_HAT (CD, LD);
-    elsif Upper_Name = "HAC_PACK" or else Upper_Name = "HAL" then
+    elsif Upper_Name in "HAC_PACK" | "HAL" then
       Error
-        (CD,
-         err_obsolete_hat_name,
-         HAT_Name,
-         Upper_Name,
-         severity => major);
+       (CD, err_obsolete_hat_name, HAT_Name, Upper_Name, severity => major);
     else
       begin
         Compile_WITHed_Unit (CD, LD, Upper_Name);


### PR DESCRIPTION
Dear HAC developers,
Dear Gautier de Montmollin,

Thinking about you request to change
```
if Code = SP_Open or Code = SP_Create or Code = SP_Append then
```
into
```
if Code in SP_Open | SP_Create | SP_Append then
```
I realized why we didn't have this find and replace pattern.

On my codebases, we always started with preferring short circuit operators.
See for more info [adaic](https://www.adaic.org/resources/add_content/docs/95style/html/sec_5/5-5-5.html)

When the code is changed and uses short circuit operators,
we apply the find-and-replace patterns to prefer membership tests.

So I exactly applied these two steps in succession on the hac archive.
And e.g. src/apps/hac_pkg.adb benefits from both!

Hopes this helps in making hac even better and easier to maintain!

Greetings,
 Pierre

P.S. A pretty printer is applied to every rewrite to ensure that no warnings are introduced (such as line too long).
However not all your code seems to adhere to the pretty print settings as specified in your project file.

Problem detected and solved by Rejuvenation-Ada crate
[![vote for Rejuvenation-Ada as The 2022 Ada Crate Of The Year](https://user-images.githubusercontent.com/18348654/191469254-1ca1f4a0-6242-43fa-94a2-f39f55817fdc.jpg)](https://github.com/AdaCore/Ada-SPARK-Crate-Of-The-Year/issues/15)