### PR TITLE
Added support for aggregates and record field default values

### DIFF
--- a/src/compile/hac_sys-co_defs.ads
+++ b/src/compile/hac_sys-co_defs.ads
@@ -19,6 +19,7 @@ with HAT;
 
 with Ada.Containers.Hashed_Maps,
      Ada.Containers.Indefinite_Hashed_Maps,
+     Ada.Containers.Vectors,
      Ada.Finalization,
      Ada.Strings.Hash,
      Ada.Strings.Unbounded.Hash,
@@ -87,6 +88,43 @@ package HAC_Sys.Co_Defs is
   end record;
 
   -------------------------------------------------------------------------
+  ---------------------------------------------------------Default_Value----
+  -------------------------------------------------------------------------
+  --  Represents a record type's compile-time-known "whole default" (RM
+  --  3.7/3.8 default_expression, restricted to static values -- see
+  --  HAC_Sys.Parser.Defaults): a Scalar_Default is one component's literal
+  --  value; a Composite_Default is a list of (Offset, Value) pairs for a
+  --  record- or array-typed component, recursively. Offset is always
+  --  relative to this node's own immediate parent (or, for the top-level
+  --  node stored on a Block_Table_Entry, relative to the record's own
+  --  base). A Default_Value tree, once built when its record type is fully
+  --  declared, is only ever read afterwards (never mutated), so the same
+  --  Default_Value_Access can safely be shared (not cloned) by every field
+  --  or array position that inherits it.
+  --
+  type Default_Value_Kind is (Scalar_Default, Composite_Default);
+  type Default_Value;
+  type Default_Value_Access is access Default_Value;
+
+  type Default_Component is record
+    Offset : HAC_Integer;
+    Value  : Default_Value_Access;
+  end record;
+
+  package Default_Component_Vectors is new Ada.Containers.Vectors (Positive, Default_Component);
+
+  type Default_Value (Kind : Default_Value_Kind := Scalar_Default) is record
+    case Kind is
+      when Scalar_Default =>
+        Scalar_Typ : Exact_Subtyp;
+        Scalar_Int : HAC_Integer;  --  Includes Character and enumeration types.
+        Scalar_R   : HAC_Float;
+      when Composite_Default =>
+        Components : Default_Component_Vectors.Vector;
+    end case;
+  end record;
+
+  -------------------------------------------------------------------------
   ------------------------------------------------------------BTabEntry----
   -------------------------------------------------------------------------
   --  Block Table Entry : Each entry represents a subprogram or a record type.
@@ -112,6 +150,13 @@ package HAC_Sys.Co_Defs is
                                        --    this block if it is a subprogram)
     SrcFrom            : Positive;     --   Source code line count.  Source starts here
     SrcTo              : Positive;     --   and goes until here    (* Manuel *)
+    Default            : Default_Value_Access := null;
+                                       --   C For a record type only: this type's whole
+                                       --   compile-time default (RM 3.7/3.8), merging
+                                       --   explicit field defaults with inherited ones
+                                       --   from nested record/array-of-record fields.
+                                       --   Null if the type has no defaults at all
+                                       --   (the common case).
   end record;
 
   fixed_area_size : constant := 5;  --  Size of area (1) described above.

--- a/src/compile/hac_sys-compiler.adb
+++ b/src/compile/hac_sys-compiler.adb
@@ -98,7 +98,8 @@ package body HAC_Sys.Compiler is
       PSize              => 0,
       VSize              => 0,
       SrcFrom            => 1,
-      SrcTo              => 1);
+      SrcTo              => 1,
+      Default            => null);
   end Init_for_new_Build;
 
   --  Print_Tables is for debugging purposes.

--- a/src/compile/hac_sys-defs.ads
+++ b/src/compile/hac_sys-defs.ads
@@ -454,6 +454,14 @@ package HAC_Sys.Defs is
      err_non_public_entity,                       --  2022-04-02
      err_choices_not_covered,
      err_choice_out_of_range,
+     err_aggregate_field_covered_twice,            --  2026-07-01
+     err_aggregate_index_covered_twice,            --  2026-07-01
+     err_aggregate_field_not_covered,              --  2026-07-01
+     err_aggregate_index_not_covered,              --  2026-07-01
+     err_aggregate_others_not_last,                --  2026-07-01
+     err_aggregate_positional_after_named,         --  2026-07-01
+     err_aggregate_others_field_types_differ,      --  2026-07-02
+     err_default_value_must_be_static,             --  2026-07-07
      err_mixed_logical_operators,
      err_library_error,
      err_wrong_unit_name,

--- a/src/compile/hac_sys-errors.adb
+++ b/src/compile/hac_sys-errors.adb
@@ -284,7 +284,29 @@ package body HAC_Sys.Errors is
         return "all case values shall be covered, either explicitly " &
                "or by ""others"" (RM 5.4 (6))" & hint_1;
       when err_choice_out_of_range =>
-        return "choice(s) out of range of case expression";
+        return "choice(s) out of range" &
+               (if hint_1 = "" then " of case expression" else ": " & hint_1);
+      when err_aggregate_field_covered_twice =>
+        return "aggregate: field """ & hint_1 & """ is covered more than once";
+      when err_aggregate_index_covered_twice =>
+        return "aggregate: index" & hint_1 & " is covered more than once";
+      when err_aggregate_field_not_covered =>
+        return "aggregate: field """ & hint_1 & """ is not covered";
+      when err_aggregate_index_not_covered =>
+        return "aggregate: all index values shall be covered, either explicitly " &
+               "or by ""others"" (RM 4.3.3)" & hint_1;
+      when err_aggregate_others_not_last =>
+        return "aggregate: ""others"" choice must be the last one";
+      when err_aggregate_positional_after_named =>
+        return "aggregate: a positional association cannot follow a named " &
+               "association (RM 4.3 (4)/(5))";
+      when err_aggregate_others_field_types_differ =>
+        return "aggregate: ""others"" applies to record fields that do not " &
+               "all have the same type";
+      when err_default_value_must_be_static =>
+        return "a record component's default value (RM 3.7 / 3.8) must be " &
+               "a static expression, or an aggregate built from static " &
+               "values" & (if hint_1 = "" then "" else ": " & hint_1);
       when err_mixed_logical_operators =>
         return "mixed logical operators in expression (RM 4.4 (2)) - " &
                "clarify by using parentheses";

--- a/src/compile/hac_sys-parser-aggregates.adb
+++ b/src/compile/hac_sys-parser-aggregates.adb
@@ -1,0 +1,874 @@
+-------------------------------------------------------------------------------------
+--
+--  HAC - HAC Ada Compiler
+--
+--  A compiler in Ada for an Ada subset
+--
+--  Copyright, license, etc. : see top package.
+--
+-------------------------------------------------------------------------------------
+--
+
+with Ada.Containers.Vectors;
+
+with HAC_Sys.Compiler.PCode_Emit,
+     HAC_Sys.Parser.Calls,
+     HAC_Sys.Parser.Expressions,
+     HAC_Sys.Parser.Helpers,
+     HAC_Sys.Parser.Ranges,
+     HAC_Sys.Parser.Standard_Functions,
+     HAC_Sys.PCode,
+     HAC_Sys.Scanner,
+     HAC_Sys.Errors;
+
+package body HAC_Sys.Parser.Aggregates is
+
+  use Compiler.PCode_Emit, Co_Defs, Defs, Expressions, Helpers, PCode, Errors;
+  use type Defs.HAC_Integer;
+
+  ------------------------------------------------------------------
+  --  A "fill template" records, once, how one "others" fill value
+  --  was computed, as a tree of independently-replayable pieces:
+  --  a Leaf_Code node is a captured range of already-emitted CD.ObjCode
+  --  (the value computation and its store/copy, *not* including the
+  --  destination-address push, which is always re-emitted fresh); a
+  --  Nested_Template node is a composite fill value that was itself a
+  --  nested aggregate literal, whose own components were captured the
+  --  same way, recursively. This is what lets "others => Expr" (RM
+  --  4.3.3) re-run Expr's underlying code once per covered component
+  --  -- including any function calls in it -- without HAC's strictly
+  --  forward-only scanner ever having to re-parse source text: see
+  --  Replay_Fill_Template_Node below, which raw-copies a Leaf_Code
+  --  node's CD.ObjCode range forward, exactly as
+  --  Const_Var.Possibly_Initialized_Constant_or_Variable already does
+  --  for relocated initializer code.
+  ------------------------------------------------------------------
+  type Fill_Template_Kind is (Leaf_Code, Nested_Template);
+  type Fill_Template;
+  type Fill_Template_Access is access Fill_Template;
+
+  package Fill_Template_Vectors is new Ada.Containers.Vectors (Positive, Fill_Template_Access);
+  subtype Fill_Template_List is Fill_Template_Vectors.Vector;
+
+  type Fill_Template (Kind : Fill_Template_Kind := Leaf_Code) is record
+    Relative_Offset : Defs.HAC_Integer;  --  relative to this node's own parent
+    case Kind is
+      when Leaf_Code =>
+        Code_First, Code_Last : Integer;  --  inclusive CD.LC range to replay
+      when Nested_Template =>
+        Children : Fill_Template_List;
+    end case;
+  end record;
+
+  --  Does the actual work of Parse_Aggregate (see the .ads for its public
+  --  contract), plus one extra parameter, Template, used only for the
+  --  internal recursive calls this body makes into itself: non-null
+  --  exactly when the aggregate currently being parsed is itself the fill
+  --  value of an ancestor "others" clause, in which case it accumulates a
+  --  replayable record of each component's emitted code so that ancestor's
+  --  own "others" can re-run it once per further position/field it covers
+  --  (RM 4.3.3). See Fill_Others below. Kept private to this body (rather
+  --  than added to Parse_Aggregate's own public profile) since
+  --  Fill_Template_List is an implementation detail with no meaning to any
+  --  external caller.
+  procedure Parse_Aggregate_Worker
+    (CD             : in out Co_Defs.Compiler_Data;
+     Block_Data     : in out Block_Data_Type;
+     Follow_Symbols :        Defs.Symset;
+     Expected       :        Co_Defs.Exact_Subtyp;
+     Dest_Level     :        Defs.Nesting_Level;
+     Dest_Base      :        Defs.HAC_Integer;
+     Template       :        access Fill_Template_List := null)
+  is
+    procedure In_Symbol is begin Scanner.In_Symbol (CD); end In_Symbol;
+
+    --  A single view of Compiler_Data's identifier table, so this package
+    --  can spell it "Id_Table" throughout instead of "id_table" (GNAT's
+    --  identifier-reference style check requires every reference to match
+    --  the casing of its own declaration -- this is a fresh, locally
+    --  declared name, so it is free to have its own casing).
+    Id_Table : Identifier_Table_Type renames CD.id_table;
+
+    --  Terminator set used while parsing one component's value expression.
+    Component_Follow_Symbols : constant Symset := Follow_Symbols + Comma_RParent;
+
+    ------------------------------------------------------------------
+    --  Appends a Leaf_Code node (Offset relative to this aggregate's own
+    --  base, and the CD.ObjCode range from Code_First through the current
+    --  CD.LC - 1) into Template, when Template is being captured (i.e. this
+    --  whole aggregate is itself the fill value of an ancestor's "others"
+    --  clause). A no-op whenever Template is null, which is the case for
+    --  the overwhelming majority of ordinary (non-nested-under-"others")
+    --  aggregates.
+    ------------------------------------------------------------------
+    procedure Capture_Leaf
+      (Template : access Fill_Template_List; Offset : HAC_Integer; Code_First : Integer)
+    is
+    begin
+      if Template /= null then
+        Template.Append (new Fill_Template'(Leaf_Code, Offset, Code_First, CD.LC - 1));
+      end if;
+    end Capture_Leaf;
+
+    --  Same, for a composite fill value that was itself a nested aggregate
+    --  literal: Children are that nested aggregate's own captured leaves.
+    procedure Capture_Nested
+      (Template : access Fill_Template_List; Offset : HAC_Integer; Children : Fill_Template_List)
+    is
+    begin
+      if Template /= null then
+        Template.Append (new Fill_Template'(Nested_Template, Offset, Children));
+      end if;
+    end Capture_Nested;
+
+    ------------------------------------------------------------------
+    --  Replays a captured fill template at a new (New_Level, New_Base):
+    --  for a Leaf_Code node, emits a fresh destination-address push at
+    --  New_Base + Node.Relative_Offset, then raw-copies the node's
+    --  captured CD.ObjCode range forward -- bypassing Emit_1/Emit_2 (and
+    --  therefore Try_Folding/Try_Specialization) entirely, exactly as
+    --  Const_Var.Possibly_Initialized_Constant_or_Variable's relocation
+    --  copy loop does, since every instruction encodes addresses as
+    --  Base + Y recomputed at run time and folding only ever inspects
+    --  the immediately-preceding instruction, never how it got there.
+    --  For a Nested_Template node, recurses over its children with the
+    --  base shifted by this node's own offset.
+    ------------------------------------------------------------------
+    procedure Replay_Fill_Template_Node
+      (Node : Fill_Template_Access; New_Level : Nesting_Level; New_Base : HAC_Integer)
+    is
+    begin
+      case Node.Kind is
+        when Leaf_Code =>
+          Emit_2
+            (CD, k_Push_Address,
+             Operand_1_Type (New_Level), Operand_2_Type (New_Base + Node.Relative_Offset));
+          for Source_LC in Node.Code_First .. Node.Code_Last loop
+            CD.LC := CD.LC + 1;
+            CD.ObjCode (CD.LC - 1) := CD.ObjCode (Source_LC);
+          end loop;
+        when Nested_Template =>
+          for Child of Node.Children loop
+            Replay_Fill_Template_Node (Child, New_Level, New_Base + Node.Relative_Offset);
+          end loop;
+      end case;
+    end Replay_Fill_Template_Node;
+
+    --  Returns a copy of Node with its own Relative_Offset shifted by
+    --  Delta_Offset. A Nested_Template's Children keep their own offsets
+    --  unchanged -- they are relative to Node itself, which moves as one
+    --  unit; only Node's own offset (relative to *its* parent) changes.
+    function Clone_With_Offset_Delta
+      (Node : Fill_Template_Access; Delta_Offset : HAC_Integer) return Fill_Template_Access
+    is
+    begin
+      case Node.Kind is
+        when Leaf_Code =>
+          return new Fill_Template'
+            (Leaf_Code, Node.Relative_Offset + Delta_Offset, Node.Code_First, Node.Code_Last);
+        when Nested_Template =>
+          return new Fill_Template'
+            (Nested_Template, Node.Relative_Offset + Delta_Offset, Node.Children);
+      end case;
+    end Clone_With_Offset_Delta;
+
+    ------------------------------------------------------------------
+    --  Emit a component (array element or record field) whose type
+    --  and compile-time byte offset (relative to Dest_Base) are known.
+    --  If the component's own type is composite and a nested aggregate
+    --  literal follows, recurse instead of materializing an intermediate
+    --  value: the recursive call writes its own leaves directly into
+    --  (Dest_Level, Dest_Base + Offset), so no k_Copy_Block is needed.
+    --  Capture_Template, when non-null, receives one node describing
+    --  what was just emitted (a Leaf_Code range or a Nested_Template),
+    --  so an enclosing "others" clause can replay it for other positions.
+    ------------------------------------------------------------------
+    procedure Emit_Component
+      (Component_Typ : Exact_Subtyp; Offset : HAC_Integer;
+       Capture_Template : access Fill_Template_List := null)
+    is
+      Found_Typ  : Exact_Subtyp;
+      Code_First : Integer;
+    begin
+      if Component_Typ.TYP in Composite_Typ and then CD.Sy = LParent then
+        declare
+          Children : aliased Fill_Template_List;
+        begin
+          Parse_Aggregate_Worker
+            (CD, Block_Data, Follow_Symbols, Component_Typ, Dest_Level, Dest_Base + Offset,
+             Template => Children'Access);
+          Capture_Nested (Capture_Template, Offset, Children);
+        end;
+      else
+        Emit_2 (CD, k_Push_Address, Operand_1_Type (Dest_Level), Operand_2_Type (Dest_Base + Offset));
+        Code_First := CD.LC;
+        Expression (CD, Block_Data.context, Component_Follow_Symbols, Found_Typ);
+        Emit_Type_Checked_Store_or_Copy (CD, Component_Typ, Found_Typ);
+        Capture_Leaf (Capture_Template, Offset, Code_First);
+      end if;
+    end Emit_Component;
+
+    ------------------------------------------------------------------
+    --  Parses the first (ambiguous) component of a positional-looking
+    --  aggregate. Per RM 4.3.3, "(Expr)" with no comma and no named
+    --  association is *never* an aggregate -- it is always a plain
+    --  parenthesized expression, checked against the whole destination
+    --  type (Expected), not against the first element/field's type.
+    --  We can only tell which case we are in once we see whether a
+    --  comma follows. Position 1 is always at offset 0 (both for an
+    --  array's first element and a record's first declared field), so
+    --  the destination address pushed here is correct either way.
+    --
+    --  Returns True if a comma was seen (confirmed multi-component
+    --  positional aggregate; the caller must continue from position 2),
+    --  or False if this was the sole content (already fully handled as
+    --  a whole-object copy; nothing more to parse for this aggregate).
+    ------------------------------------------------------------------
+    function Parse_First_Component_Or_Whole_Object
+      (First_Component_Typ : Exact_Subtyp) return Boolean
+    is
+      Found_Typ  : Exact_Subtyp;
+      Code_First : Integer;
+    begin
+      if First_Component_Typ.TYP in Composite_Typ and then CD.Sy = LParent then
+        --  Offset is always 0 for position 1: leaves flatten directly into
+        --  the ambient Template, exactly as if this call were itself one
+        --  ordinary component of the enclosing aggregate.
+        Parse_Aggregate_Worker
+          (CD, Block_Data, Follow_Symbols, First_Component_Typ, Dest_Level, Dest_Base,
+           Template => Template);
+        return CD.Sy = Comma;
+      else
+        Emit_2 (CD, k_Push_Address, Operand_1_Type (Dest_Level), Operand_2_Type (Dest_Base));
+        Code_First := CD.LC;
+        Expression (CD, Block_Data.context, Component_Follow_Symbols, Found_Typ);
+        if CD.Sy = Comma then
+          Emit_Type_Checked_Store_or_Copy (CD, First_Component_Typ, Found_Typ);
+          Capture_Leaf (Template, 0, Code_First);
+          return True;
+        else
+          Emit_Type_Checked_Store_or_Copy (CD, Expected, Found_Typ);
+          --  Sole content, not a multi-component aggregate at all -- Template
+          --  cannot be non-null here (see Emit_Component/Fill_Others, which
+          --  never dispatch into a "known composite, multi-component"
+          --  Parse_Aggregate call with Template set unless a comma is
+          --  guaranteed to have been seen for this alternative to matter).
+          return False;
+        end if;
+      end if;
+    end Parse_First_Component_Or_Whole_Object;
+
+    ------------------------------------------------------------------
+    --  Array aggregates.
+    ------------------------------------------------------------------
+    procedure Parse_Array_Aggregate is
+      Array_Entry  : Array_Table_Entry renames CD.Arrays_Table (Expected.Ref);
+      Lower_Bound  : constant HAC_Integer := Array_Entry.Index_xTyp.Discrete_First;
+      Upper_Bound  : constant HAC_Integer := Array_Entry.Index_xTyp.Discrete_Last;
+      Element_Typ  : constant Exact_Subtyp := Array_Entry.Element_xTyp;
+      Element_Size : constant HAC_Integer := HAC_Integer (Array_Entry.Element_Size);
+
+      Covered : array (HAC_Integer range Lower_Bound .. Upper_Bound) of Boolean := (others => False);
+
+      function Offset_Of (Array_Index : HAC_Integer) return HAC_Integer is
+        ((Array_Index - Lower_Bound) * Element_Size);
+
+      procedure Mark_Covered (Array_Index : HAC_Integer) is
+      begin
+        if Array_Index not in Lower_Bound .. Upper_Bound then
+          Error
+            (CD, err_choice_out_of_range,
+             "index" & HAC_Integer'Image (Array_Index) & " is out of the array's range, " &
+             HAC_Integer'Image (Lower_Bound) & " .." & HAC_Integer'Image (Upper_Bound),
+             severity => minor);
+        elsif Covered (Array_Index) then
+          Error (CD, err_aggregate_index_covered_twice, HAC_Integer'Image (Array_Index), severity => minor);
+        else
+          Covered (Array_Index) := True;
+        end if;
+      end Mark_Covered;
+
+      procedure Check_Full_Coverage is
+      begin
+        for Array_Index in Lower_Bound .. Upper_Bound loop
+          if not Covered (Array_Index) then
+            Error (CD, err_aggregate_index_not_covered, "", severity => minor);
+            exit;
+          end if;
+        end loop;
+      end Check_Full_Coverage;
+
+      --  Parses and fills "others => Expr" for every remaining (not yet
+      --  covered) position. Since bounds are always static in HAC, every
+      --  remaining position is known at compile time. Expr is parsed once,
+      --  directly into the first remaining position, while Emit_Component
+      --  captures a replayable template of the code it emitted (whether a
+      --  scalar/whole-value computation or, for a nested-aggregate fill
+      --  value such as "others => (others => 0)", a whole subtree of
+      --  captured leaves) -- then that template is replayed (cloned with a
+      --  shifted offset, emitting fresh destination-address pushes and
+      --  raw-copied leaf code) once per remaining position, so any function
+      --  calls or other side effects in Expr genuinely re-run once per
+      --  position, per RM 4.3.3.
+      procedure Fill_Others is
+        Local_Root : aliased Fill_Template_List;
+        Effective_Template : constant not null access Fill_Template_List :=
+          (if Template /= null then Template else Local_Root'Access);
+        First_Remaining : HAC_Integer := Lower_Bound;
+        Found_Any       : Boolean := False;
+      begin
+        In_Symbol;  --  Consume OTHERS_Symbol.
+        Need (CD, Finger, err_FINGER_missing);
+        for Array_Index in Lower_Bound .. Upper_Bound loop
+          if not Covered (Array_Index) then
+            First_Remaining := Array_Index;
+            Found_Any := True;
+            exit;
+          end if;
+        end loop;
+        if not Found_Any then
+          --  Nothing left to cover (e.g. "(1, 2, others => X)" for a
+          --  2-element array); still parse (and discard) the value once,
+          --  so the parser stays positioned correctly.
+          declare
+            Discard : Exact_Subtyp;
+          begin
+            Expression (CD, Block_Data.context, Follow_Symbols + Comma_RParent, Discard);
+          end;
+        else
+          Emit_Component (Element_Typ, Offset_Of (First_Remaining), Effective_Template);
+          Covered (First_Remaining) := True;
+          declare
+            Captured : constant Fill_Template_Access := Effective_Template.Last_Element;
+          begin
+            for Array_Index in Lower_Bound .. Upper_Bound loop
+              if not Covered (Array_Index) then
+                declare
+                  Cloned : constant Fill_Template_Access :=
+                    Clone_With_Offset_Delta
+                      (Captured, Offset_Of (Array_Index) - Offset_Of (First_Remaining));
+                begin
+                  Replay_Fill_Template_Node (Cloned, Dest_Level, Dest_Base);
+                  --  Also recorded, so a further ancestor's own capture
+                  --  (this whole array being nested under yet another
+                  --  "others") sees every position, not just the first.
+                  Effective_Template.Append (Cloned);
+                end;
+                Covered (Array_Index) := True;
+              end if;
+            end loop;
+          end;
+        end if;
+        if CD.Sy = Comma then
+          --  "others" was not the last association (RM 4.3.3 (5)).
+          Error (CD, err_aggregate_others_not_last, severity => major);
+        end if;
+      end Fill_Others;
+
+      --  Pushes the destination address, the literal Literal_Value (of kind
+      --  Literal_Symbol), and returns its (singleton-range) Exact_Subtyp --
+      --  shared by the first ambiguous component and by Continue_Positional,
+      --  so a literal choice's value is emitted identically in both places.
+      --  Code_First reports the point right after the destination-address
+      --  push, for the caller to hand to Capture_Leaf once it has also
+      --  emitted this component's store.
+      function Push_Literal_Component
+        (Literal_Symbol : Symbol; Literal_Value : HAC_Integer; Offset : HAC_Integer;
+         Code_First     : out Integer) return Exact_Subtyp
+      is
+        Found_Typ : Exact_Subtyp;
+      begin
+        Emit_2 (CD, k_Push_Address, Operand_1_Type (Dest_Level), Operand_2_Type (Dest_Base + Offset));
+        Code_First := CD.LC;
+        Found_Typ.Construct_Root (if Literal_Symbol = character_literal then Chars else Ints);
+        CD.target.Emit_Push_Discrete_Literal (Literal_Value);
+        Ranges.Set_Singleton_Range (Found_Typ, Literal_Value);
+        return Found_Typ;
+      end Push_Literal_Component;
+
+      --  Continues a positional array aggregate from Starting_Index. A plain
+      --  "others => Expr" may appear as the last association even after
+      --  positional ones (the common "(1, 2, others => 0)" idiom).
+      procedure Continue_Positional (Starting_Index : HAC_Integer) is
+        Next_Index : HAC_Integer := Starting_Index;
+      begin
+        while CD.Sy = Comma loop
+          In_Symbol;  --  Consume ','.
+          if CD.Sy = OTHERS_Symbol then
+            Fill_Others;
+            exit;
+          end if;
+          if Next_Index > Upper_Bound then
+            Error (CD, err_general_error, "too many components in array aggregate", severity => minor);
+            exit;
+          end if;
+          if CD.Sy in integer_literal | character_literal then
+            --  Peek: is this actually a named choice illegally following
+            --  positional associations (RM 4.3 (4)/(5))?
+            declare
+              Peek_Symbol : constant Symbol     := CD.Sy;
+              Peek_Value  : constant HAC_Integer := CD.INum;
+            begin
+              In_Symbol;
+              if CD.Sy = Finger then
+                Error (CD, err_aggregate_positional_after_named, severity => major);
+                exit;
+              end if;
+              --  Not a named choice after all: genuinely this position's value.
+              declare
+                Code_First : Integer;
+                Found_Typ  : constant Exact_Subtyp :=
+                  Push_Literal_Component (Peek_Symbol, Peek_Value, Offset_Of (Next_Index), Code_First);
+              begin
+                Emit_Type_Checked_Store_or_Copy (CD, Element_Typ, Found_Typ);
+                Capture_Leaf (Template, Offset_Of (Next_Index), Code_First);
+              end;
+            end;
+          else
+            Emit_Component (Element_Typ, Offset_Of (Next_Index), Template);
+          end if;
+          Mark_Covered (Next_Index);
+          Next_Index := Next_Index + 1;
+        end loop;
+        Check_Full_Coverage;
+      end Continue_Positional;
+
+    begin
+      if CD.Sy = OTHERS_Symbol then
+        Fill_Others;
+      elsif CD.Sy in integer_literal | character_literal then
+        declare
+          Choice_Symbol : constant Symbol     := CD.Sy;
+          Choice_Value  : constant HAC_Integer := CD.INum;
+        begin
+          In_Symbol;  --  Peek past the literal.
+          if CD.Sy = Finger then
+            --  Confirmed named form: "Choice_Value => Value".
+            In_Symbol;  --  Consume '=>'.
+            Mark_Covered (Choice_Value);
+            Emit_Component (Element_Typ, Offset_Of (Choice_Value), Template);
+            while CD.Sy = Comma loop
+              In_Symbol;
+              if CD.Sy = OTHERS_Symbol then
+                Fill_Others;
+                exit;
+              elsif CD.Sy in integer_literal | character_literal then
+                declare
+                  Next_Choice_Value : constant HAC_Integer := CD.INum;
+                begin
+                  In_Symbol;
+                  Need (CD, Finger, err_FINGER_missing);
+                  Mark_Covered (Next_Choice_Value);
+                  Emit_Component (Element_Typ, Offset_Of (Next_Choice_Value), Template);
+                end;
+              else
+                Error
+                  (CD, err_not_yet_implemented,
+                   "this kind of array aggregate choice (only literal indices " &
+                   "and ""others"" are supported)",
+                   severity => major);
+                exit;
+              end if;
+            end loop;
+            Check_Full_Coverage;
+          else
+            --  Positional: the first component's value is this literal,
+            --  already consumed while peeking.
+            declare
+              Code_First : Integer;
+              Found_Typ  : constant Exact_Subtyp :=
+                Push_Literal_Component (Choice_Symbol, Choice_Value, 0, Code_First);
+            begin
+              if CD.Sy = Comma then
+                Emit_Type_Checked_Store_or_Copy (CD, Element_Typ, Found_Typ);
+                Capture_Leaf (Template, 0, Code_First);
+                Mark_Covered (Lower_Bound);
+                Continue_Positional (Lower_Bound + 1);
+              else
+                --  Sole bare literal: whole-object check against Expected.
+                Emit_Type_Checked_Store_or_Copy (CD, Expected, Found_Typ);
+              end if;
+            end;
+          end if;
+        end;
+      else
+        --  Generic first component: nested aggregate, identifier, function
+        --  call, parenthesized sub-expression, unary operator, ...
+        if Parse_First_Component_Or_Whole_Object (Element_Typ) then
+          Mark_Covered (Lower_Bound);
+          Continue_Positional (Lower_Bound + 1);
+        end if;
+      end if;
+    end Parse_Array_Aggregate;
+
+    ------------------------------------------------------------------
+    --  Record aggregates.
+    ------------------------------------------------------------------
+    procedure Parse_Record_Aggregate is
+      Field_Count   : Natural := 0;
+      Counting_Walk : Integer := CD.Blocks_Table (Expected.Ref).Last_Id_Idx;
+    begin
+      while Counting_Walk /= No_Id loop
+        Field_Count := Field_Count + 1;
+        Counting_Walk := Id_Table (Counting_Walk).link;
+      end loop;
+      if Field_Count = 0 then
+        return;
+      end if;
+      declare
+        --  Field Id_Table indices, in forward (declaration) order.
+        Fields        : array (1 .. Field_Count) of Integer;
+        Covered       : array (1 .. Field_Count) of Boolean := (others => False);
+        Building_Walk : Integer := CD.Blocks_Table (Expected.Ref).Last_Id_Idx;
+
+        function Position_Of (Field_Id : Integer) return Natural is
+        begin
+          for Position in Fields'Range loop
+            if Fields (Position) = Field_Id then
+              return Position;
+            end if;
+          end loop;
+          return 0;
+        end Position_Of;
+
+        procedure Mark_Covered (Position : Natural) is
+        begin
+          if Position = 0 then
+            null;  --  Unresolved field; error already reported by the caller.
+          elsif Covered (Position) then
+            Error
+              (CD, err_aggregate_field_covered_twice,
+               A2S (Id_Table (Fields (Position)).name_with_case), severity => minor);
+          else
+            Covered (Position) := True;
+          end if;
+        end Mark_Covered;
+
+        procedure Check_Full_Coverage is
+        begin
+          for Position in Covered'Range loop
+            if not Covered (Position) then
+              Error
+                (CD, err_aggregate_field_not_covered,
+                 A2S (Id_Table (Fields (Position)).name_with_case), severity => minor);
+            end if;
+          end loop;
+        end Check_Full_Coverage;
+
+        procedure Emit_Field (Position : Positive; Capture_Template : access Fill_Template_List := null) is
+        begin
+          Emit_Component
+            (Id_Table (Fields (Position)).xtyp, Id_Table (Fields (Position)).adr_or_sz, Capture_Template);
+        end Emit_Field;
+
+        --  Resolves an already-consumed identifier (so Locate_CD_Id's
+        --  reliance on the *current* token cannot be used) as either a
+        --  direct_name (RM 4.1) reference -- an object/constant/parameter,
+        --  or a declared number or enumeration literal (e.g. True/False) --
+        --  or the start of a function_call (RM 6.4): CD.Sy is already
+        --  positioned right after the identifier, e.g. at '(' for the
+        --  argument list, exactly as Primary.Process_Identifier expects
+        --  when it dispatches to Calls.Subprogram_or_Entry_Call /
+        --  Standard_Functions.Standard_Function. Used whenever a positional
+        --  record component's first token is an identifier that turned out
+        --  (after peeking) *not* to be one of this record's own field names
+        --  in named-association form.
+        function Resolve_Direct_Name_Or_Call_Value (Name : Alfa) return Exact_Subtyp is
+          Identifier_Id : constant Natural :=
+            Locate_Identifier (CD, Name, Block_Data.context.level, Fail_when_No_Id => False);
+          Found_Typ : Exact_Subtyp := undefined_subtyp;
+        begin
+          if Identifier_Id = No_Id then
+            Error (CD, err_undefined_identifier, A2S (Name), severity => major);
+            return Found_Typ;
+          end if;
+          declare
+            Identifier_Entry : Identifier_Table_Entry renames Id_Table (Identifier_Id);
+          begin
+            Found_Typ := Identifier_Entry.xtyp;
+            case Identifier_Entry.entity is
+              when Object_Kind =>
+                Emit_2
+                  (CD,
+                   (if Standard_or_Enum_Typ (Found_Typ.TYP) then
+                      (if Identifier_Entry.normal then
+                         (if Discrete_Typ (Identifier_Entry.xtyp.TYP) then
+                            k_Push_Discrete_Value
+                          else
+                            k_Push_Value)
+                       else k_Push_Indirect_Value)
+                    elsif Identifier_Entry.normal then k_Push_Address
+                    else k_Push_Discrete_Value),
+                   Operand_1_Type (Identifier_Entry.lev), Operand_2_Type (Identifier_Entry.adr_or_sz));
+                Mark_Read_and_Check_Read_before_Written (CD, Block_Data.context, Identifier_Entry);
+              when declared_number_or_enum_item =>
+                if Found_Typ.TYP = Floats then
+                  Emit_1 (CD, k_Push_Float_Literal, Operand_2_Type (Identifier_Entry.adr_or_sz));
+                else
+                  Emit_1 (CD, k_Push_Discrete_Literal, Operand_2_Type (Identifier_Entry.adr_or_sz));
+                  Ranges.Set_Singleton_Range (Found_Typ, Identifier_Entry.adr_or_sz);
+                end if;
+              when funktion =>
+                Calls.Subprogram_or_Entry_Call
+                  (CD, Block_Data.context, Component_Follow_Symbols, Identifier_Id, Normal_Procedure_Call);
+              when funktion_intrinsic =>
+                Standard_Functions.Standard_Function
+                  (CD, Block_Data.context, Component_Follow_Symbols, Identifier_Id,
+                   SF_Code'Val (Identifier_Entry.adr_or_sz), Found_Typ);
+              when others =>
+                Error
+                  (CD, err_not_yet_implemented,
+                   "this kind of positional record aggregate component (attributes, " &
+                   "selected/indexed components) starting with an identifier",
+                   severity => major);
+            end case;
+          end;
+          return Found_Typ;
+        end Resolve_Direct_Name_Or_Call_Value;
+
+        --  Parses and fills "others => Expr" for the remaining (not yet
+        --  covered) fields. Ada allows this only when every field "others"
+        --  applies to shares the same type; check that first. Expr is
+        --  parsed once, directly into the first remaining field, while
+        --  Emit_Field/Emit_Component capture a replayable template of the
+        --  code emitted; that template is then replayed (cloned with a
+        --  shifted offset) once per remaining field, so side effects in
+        --  Expr re-run once per field, per RM 4.3.3.
+        procedure Fill_Others is
+          Common_Typ      : Exact_Subtyp;
+          Any_Uncovered   : Boolean := False;
+          Types_Differ    : Boolean := False;
+          First_Remaining : Natural := 0;
+        begin
+          for Position in Covered'Range loop
+            if not Covered (Position) then
+              declare
+                This_Typ : constant Exact_Subtyp := Id_Table (Fields (Position)).xtyp;
+              begin
+                if not Any_Uncovered then
+                  Common_Typ := This_Typ;
+                  Any_Uncovered := True;
+                  First_Remaining := Position;
+                elsif Common_Typ.TYP /= This_Typ.TYP or else Common_Typ.Ref /= This_Typ.Ref then
+                  Types_Differ := True;
+                end if;
+              end;
+            end if;
+          end loop;
+          In_Symbol;  --  Consume OTHERS_Symbol.
+          Need (CD, Finger, err_FINGER_missing);
+          if Types_Differ then
+            Error (CD, err_aggregate_others_field_types_differ, severity => major);
+          end if;
+          if not Any_Uncovered then
+            --  Nothing left to cover; still parse (and discard) the value so
+            --  the parser stays positioned correctly.
+            declare
+              Discard : Exact_Subtyp;
+            begin
+              Expression (CD, Block_Data.context, Component_Follow_Symbols, Discard);
+            end;
+          elsif Types_Differ then
+            --  Legality error already reported above; still parse (and
+            --  discard) the value so the parser stays positioned correctly,
+            --  matching the "nothing left to cover" branch.
+            declare
+              Discard : Exact_Subtyp;
+            begin
+              Expression (CD, Block_Data.context, Component_Follow_Symbols, Discard);
+            end;
+          else
+            declare
+              Local_Root : aliased Fill_Template_List;
+              Effective_Template : constant not null access Fill_Template_List :=
+                (if Template /= null then Template else Local_Root'Access);
+            begin
+              Emit_Field (First_Remaining, Effective_Template);
+              Covered (First_Remaining) := True;
+              declare
+                Captured : constant Fill_Template_Access := Effective_Template.Last_Element;
+              begin
+                for Position in Covered'Range loop
+                  if not Covered (Position) then
+                    declare
+                      Cloned : constant Fill_Template_Access :=
+                        Clone_With_Offset_Delta
+                          (Captured,
+                           Id_Table (Fields (Position)).adr_or_sz -
+                             Id_Table (Fields (First_Remaining)).adr_or_sz);
+                    begin
+                      Replay_Fill_Template_Node (Cloned, Dest_Level, Dest_Base);
+                      Effective_Template.Append (Cloned);
+                    end;
+                    Covered (Position) := True;
+                  end if;
+                end loop;
+              end;
+            end;
+          end if;
+          if CD.Sy = Comma then
+            --  "others" was not the last association (RM 4.3.3 (5)).
+            Error (CD, err_aggregate_others_not_last, severity => major);
+          end if;
+        end Fill_Others;
+
+        --  Continues a positional record aggregate from position 2 (field 1
+        --  is already filled by the caller). Shared by both entry points
+        --  that can reach a confirmed positional aggregate: the ordinary
+        --  first-component case in Parse_First_Component_Or_Whole_Object,
+        --  and the case where the first token was an identifier that
+        --  turned out (after peeking) not to be a named field association.
+        procedure Continue_Positional_Record is
+          Position : Positive := 2;
+        begin
+          while CD.Sy = Comma loop
+            In_Symbol;  --  Consume ','.
+            if CD.Sy = OTHERS_Symbol then
+              Fill_Others;
+              exit;
+            end if;
+            if Position > Field_Count then
+              Error (CD, err_general_error, "too many components in record aggregate", severity => minor);
+              exit;
+            end if;
+            if CD.Sy = IDent then
+              --  Peek: is this actually a named field association
+              --  illegally following positional ones (RM 4.3 (4)/(5))?
+              declare
+                Peek_Name     : constant Alfa   := CD.Id;
+                Peek_Field_Id : constant Integer := Locate_Record_Field (CD, Expected.Ref, Peek_Name);
+              begin
+                In_Symbol;
+                if Peek_Field_Id /= No_Id and then CD.Sy = Finger then
+                  Error (CD, err_aggregate_positional_after_named, severity => major);
+                  exit;
+                end if;
+                --  Genuinely a positional value starting with a bare
+                --  identifier (a variable/constant reference, an
+                --  enumeration literal such as True/False, or a function
+                --  call).
+                declare
+                  Offset     : constant HAC_Integer := Id_Table (Fields (Position)).adr_or_sz;
+                  Code_First : Integer;
+                begin
+                  Emit_2 (CD, k_Push_Address, Operand_1_Type (Dest_Level), Operand_2_Type (Dest_Base + Offset));
+                  Code_First := CD.LC;
+                  Emit_Type_Checked_Store_or_Copy
+                    (CD, Id_Table (Fields (Position)).xtyp,
+                     Resolve_Direct_Name_Or_Call_Value (Peek_Name));
+                  Capture_Leaf (Template, Offset, Code_First);
+                end;
+              end;
+            else
+              Emit_Field (Position, Template);
+            end if;
+            Mark_Covered (Position);
+            Position := Position + 1;
+          end loop;
+          Check_Full_Coverage;
+        end Continue_Positional_Record;
+
+      begin
+        for Position in reverse Fields'Range loop
+          Fields (Position) := Building_Walk;
+          Building_Walk := Id_Table (Building_Walk).link;
+        end loop;
+
+        if CD.Sy = OTHERS_Symbol then
+          Fill_Others;
+          Check_Full_Coverage;
+        elsif CD.Sy = IDent then
+          declare
+            Choice_Name : constant Alfa   := CD.Id;
+            Field_Id    : constant Integer := Locate_Record_Field (CD, Expected.Ref, Choice_Name);
+          begin
+            In_Symbol;  --  Peek past the identifier.
+            if Field_Id /= No_Id and then CD.Sy = Finger then
+              --  Confirmed named form.
+              In_Symbol;  --  Consume '=>'.
+              Mark_Covered (Position_Of (Field_Id));
+              Emit_Field (Position_Of (Field_Id), Template);
+              while CD.Sy = Comma loop
+                In_Symbol;
+                if CD.Sy = OTHERS_Symbol then
+                  Fill_Others;
+                  exit;
+                end if;
+                if CD.Sy /= IDent then
+                  Error (CD, err_identifier_missing, severity => major);
+                  exit;
+                end if;
+                declare
+                  Next_Field_Name : constant Alfa   := CD.Id;
+                  Next_Field_Id   : constant Integer := Locate_Record_Field (CD, Expected.Ref, Next_Field_Name);
+                begin
+                  In_Symbol;
+                  if Next_Field_Id = No_Id then
+                    Error (CD, err_undefined_identifier, A2S (CD.Id_with_case), severity => major);
+                    exit;
+                  end if;
+                  Need (CD, Finger, err_FINGER_missing);
+                  Mark_Covered (Position_Of (Next_Field_Id));
+                  Emit_Field (Position_Of (Next_Field_Id), Template);
+                end;
+              end loop;
+              Check_Full_Coverage;
+            else
+              --  Not a named field association: the already-consumed
+              --  identifier is not one of this record's own field names,
+              --  so resolve it as an ordinary value and treat it as this
+              --  aggregate's first (ambiguous) component -- mirrors
+              --  Parse_First_Component_Or_Whole_Object, which cannot be
+              --  reused directly here since the identifier had to be
+              --  looked up as a possible field name first (and consumed
+              --  in the process).
+              declare
+                Code_First : Integer;
+                Found_Typ  : Exact_Subtyp;
+              begin
+                Emit_2 (CD, k_Push_Address, Operand_1_Type (Dest_Level), Operand_2_Type (Dest_Base));
+                Code_First := CD.LC;
+                Found_Typ := Resolve_Direct_Name_Or_Call_Value (Choice_Name);
+                if CD.Sy = Comma then
+                  Emit_Type_Checked_Store_or_Copy (CD, Id_Table (Fields (1)).xtyp, Found_Typ);
+                  Capture_Leaf (Template, 0, Code_First);
+                  Mark_Covered (1);
+                  Continue_Positional_Record;
+                else
+                  --  Sole bare identifier: whole-object check against Expected.
+                  Emit_Type_Checked_Store_or_Copy (CD, Expected, Found_Typ);
+                end if;
+              end;
+            end if;
+          end;
+        else
+          if Parse_First_Component_Or_Whole_Object (Id_Table (Fields (1)).xtyp) then
+            Mark_Covered (1);
+            Continue_Positional_Record;
+          end if;
+        end if;
+      end;
+    end Parse_Record_Aggregate;
+
+  begin
+    In_Symbol;  --  Consume '('.
+    case Composite_Typ (Expected.TYP) is
+      when Arrays  => Parse_Array_Aggregate;
+      when Records => Parse_Record_Aggregate;
+    end case;
+    Need (CD, RParent, err_closing_parenthesis_missing);
+  end Parse_Aggregate_Worker;
+
+  procedure Parse_Aggregate
+    (CD             : in out Co_Defs.Compiler_Data;
+     Block_Data     : in out Block_Data_Type;
+     Follow_Symbols :        Defs.Symset;
+     Expected       :        Co_Defs.Exact_Subtyp;
+     Dest_Level     :        Defs.Nesting_Level;
+     Dest_Base      :        Defs.HAC_Integer)
+  is
+  begin
+    Parse_Aggregate_Worker (CD, Block_Data, Follow_Symbols, Expected, Dest_Level, Dest_Base);
+  end Parse_Aggregate;
+
+end HAC_Sys.Parser.Aggregates;

--- a/src/compile/hac_sys-parser-aggregates.ads
+++ b/src/compile/hac_sys-parser-aggregates.ads
@@ -1,0 +1,48 @@
+-------------------------------------------------------------------------------------
+--
+--  HAC - HAC Ada Compiler
+--
+--  A compiler in Ada for an Ada subset
+--
+--  Copyright, license, etc. : see top package.
+--
+-------------------------------------------------------------------------------------
+--
+--  Aggregates (RM 4.3): "(1, 2, 3)", "(Field => Value, ...)", "(others => 0)", ...
+--
+--  Called only from the two contexts where the destination's composite type
+--  is already known before any of the aggregate's contents are parsed:
+--  object declaration initializers (Const_Var) and assignment statements
+--  (Statements.Assignment). Since HAC only supports constrained array and
+--  record types, every component's position (array index, record field) is
+--  known at compile time, so aggregates are compiled by pure compile-time
+--  unrolling into the same k_Push_Address / k_Store / k_Copy_Block
+--  instructions used for ordinary assignments -- no new P-code opcodes or
+--  VM changes are needed.
+
+private package HAC_Sys.Parser.Aggregates is
+
+  --  Precondition: CD.Sy = LParent, not yet consumed.
+  --  Consumes the aggregate through its closing ')'.
+  --
+  --  Expected       : the destination's (or, when recursing, a component's)
+  --                   type; must be Arrays or Records.
+  --  Block_Data     : the enclosing block's data (nesting level and
+  --                   flow-analysis state).
+  --  Follow_Symbols : the set of symbols allowed to follow this aggregate,
+  --                   used for error recovery and to bound sub-expression
+  --                   parsing (the classic recursive-descent "follow set").
+  --  Dest_Level     : the destination's lexical level.
+  --  Dest_Base      : the destination's compile-time-constant base address
+  --                   (adr_or_sz); every component is written at
+  --                   Dest_Base + <compile-time offset>.
+  --
+  procedure Parse_Aggregate
+    (CD             : in out Co_Defs.Compiler_Data;
+     Block_Data     : in out Block_Data_Type;
+     Follow_Symbols :        Defs.Symset;
+     Expected       :        Co_Defs.Exact_Subtyp;
+     Dest_Level     :        Defs.Nesting_Level;
+     Dest_Base      :        Defs.HAC_Integer);
+
+end HAC_Sys.Parser.Aggregates;

--- a/src/compile/hac_sys-parser-const_var.adb
+++ b/src/compile/hac_sys-parser-const_var.adb
@@ -1,6 +1,7 @@
 with HAC_Sys.Compiler.PCode_Emit,
      HAC_Sys.Co_Defs,
      HAC_Sys.Defs,
+     HAC_Sys.Parser.Defaults,
      HAC_Sys.Parser.Enter_Def,
      HAC_Sys.Parser.Expressions,
      HAC_Sys.Parser.Helpers,
@@ -36,7 +37,7 @@ package body HAC_Sys.Parser.Const_Var is
         --  Example:
         --     for:            "a, b, c : Real := F (x);"
         --     we do first:    "c := F (x)".
-        Statements.Assignment (CD, FSys, Block_Data.context, id_last, check_is_variable => False);
+        Statements.Assignment (CD, FSys, Block_Data, id_last, check_is_variable => False);
         CD.id_table (id_last).is_initialized := explicit;
         --  Id_Last has been assigned.
         --  Now, we emit the code for copying the value
@@ -71,15 +72,27 @@ package body HAC_Sys.Parser.Const_Var is
           var.is_initialized := explicit;
         end loop;
       else
-        --  Implicit initialization (for instance, VString's and File_Type's).
+        --  Implicit initialization (for instance, VString's and File_Type's,
+        --  or a record/array type carrying (possibly deeply nested, RM
+        --  3.3.1) component defaults, RM 3.7/3.8 -- see
+        --  HAC_Sys.Parser.Defaults).
         for var of CD.id_table (id_first .. id_last) loop
           if Auto_Init_Typ (var.xtyp.TYP) then
             Emit_2 (CD, k_Push_Address, var.lev, Operand_2_Type (var.adr_or_sz));
             Emit_1 (CD, k_Variable_Initialization, Typen'Pos (var.xtyp.TYP));
             var.is_initialized := implicit;
+          elsif var.xtyp.TYP in Composite_Typ then
+            declare
+              Var_Default : constant Default_Value_Access := Defaults.Inherited_Default (CD, var.xtyp);
+            begin
+              if Var_Default /= null then
+                Defaults.Emit_Default_Value (CD, var.lev, var.adr_or_sz, Var_Default);
+                var.is_initialized := implicit;
+              end if;
+            end;
           end if;
-          --  !!  TBD: Must handle composite types (arrays or records) containing
-          --           initialized types, too... Bug #2
+          --  !!  TBD: Must handle composite types (arrays) containing
+          --           initialized types (VString/Text_File), too... Bug #2
         end loop;
       end if;
       --

--- a/src/compile/hac_sys-parser-defaults.adb
+++ b/src/compile/hac_sys-parser-defaults.adb
@@ -1,0 +1,456 @@
+-------------------------------------------------------------------------------------
+--
+--  HAC - HAC Ada Compiler
+--
+--  A compiler in Ada for an Ada subset
+--
+--  Copyright, license, etc. : see top package.
+--
+-------------------------------------------------------------------------------------
+--
+
+with HAC_Sys.Compiler.PCode_Emit,
+     HAC_Sys.Parser.Expressions,
+     HAC_Sys.Parser.Helpers,
+     HAC_Sys.PCode,
+     HAC_Sys.Scanner,
+     HAC_Sys.Errors;
+
+package body HAC_Sys.Parser.Defaults is
+
+  use Compiler.PCode_Emit, Co_Defs, Defs, Helpers, PCode, Errors;
+  use type Defs.HAC_Integer;
+
+  function Parse_Static_Default_Value
+    (CD       : in out Co_Defs.Compiler_Data;
+     Level    :        Defs.Nesting_Level;
+     FSys     :        Defs.Symset;
+     Expected :        Co_Defs.Exact_Subtyp) return Co_Defs.Default_Value_Access
+  is
+    procedure In_Symbol is begin Scanner.In_Symbol (CD); end In_Symbol;
+
+    Id_Table : Identifier_Table_Type renames CD.id_table;
+
+    Component_Follow : constant Symset := FSys + Comma_RParent;
+
+    ------------------------------------------------------------------
+    --  Resolves an already-consumed identifier as a static value: only
+    --  a declared number or enumeration literal qualifies (a variable,
+    --  constant, or function reference is out of scope for a static
+    --  default -- see the package's header comment).
+    ------------------------------------------------------------------
+    function Resolve_Static_Direct_Name (Name : Alfa) return Default_Value_Access is
+      Identifier_Id : constant Natural :=
+        Locate_Identifier (CD, Name, Level, Fail_when_No_Id => False);
+    begin
+      if Identifier_Id = No_Id
+        or else Id_Table (Identifier_Id).entity /= declared_number_or_enum_item
+      then
+        Error (CD, err_default_value_must_be_static, A2S (Name), severity => major);
+        return new Default_Value'
+          (Scalar_Default, undefined_subtyp, 0, 0.0);
+      end if;
+      declare
+        Entry_Ref : Identifier_Table_Entry renames Id_Table (Identifier_Id);
+      begin
+        return new Default_Value'
+          (Scalar_Default, Entry_Ref.xtyp,
+           (if Entry_Ref.xtyp.TYP = Floats then 0 else Entry_Ref.adr_or_sz),
+           (if Entry_Ref.xtyp.TYP = Floats
+            then CD.Float_Constants_Table (Integer (Entry_Ref.adr_or_sz))
+            else 0.0));
+      end;
+    end Resolve_Static_Direct_Name;
+
+    function Parse_Static_Scalar_Value (Scalar_Typ : Exact_Subtyp) return Default_Value_Access is
+      pragma Unreferenced (Scalar_Typ);
+      C : Constant_Rec;
+    begin
+      Expressions.Static_Scalar_Expression (CD, Level, Component_Follow, C);
+      --  C.R is only meaningfully set by Static_Scalar_Expression when
+      --  C.TP.TYP = Floats -- for any other (discrete) result, C.R is left
+      --  untouched (possibly uninitialized), so it must not be read here.
+      return new Default_Value'
+        (Scalar_Default, C.TP, C.I, (if C.TP.TYP = Floats then C.R else 0.0));
+    end Parse_Static_Scalar_Value;
+
+    function Parse_Static_Composite_Value
+      (Composite_Expected : Exact_Subtyp) return Default_Value_Access;
+    --  Forward declaration: needed since array/record parsing below may
+    --  recurse into a nested composite default.
+
+    ------------------------------------------------------------------
+    --  Array defaults: "(Value, Value, ...)", "(Index => Value, ...)",
+    --  "(others => Value)" -- mirrors the shape of
+    --  Aggregates.Parse_Array_Aggregate's coverage tracking, but builds a
+    --  Default_Value tree instead of emitting code, and never needs the
+    --  Fill_Template capture/replay mechanism: since every value here is
+    --  static, the *same* computed Default_Value_Access can simply be
+    --  reused (shared, not cloned) for every position "others" covers.
+    ------------------------------------------------------------------
+    function Parse_Array_Default (Array_Expected : Exact_Subtyp) return Default_Value_Access is
+      Array_Entry  : Array_Table_Entry renames CD.Arrays_Table (Array_Expected.Ref);
+      Lower_Bound  : constant HAC_Integer := Array_Entry.Index_xTyp.Discrete_First;
+      Upper_Bound  : constant HAC_Integer := Array_Entry.Index_xTyp.Discrete_Last;
+      Element_Typ  : constant Exact_Subtyp := Array_Entry.Element_xTyp;
+      Element_Size : constant HAC_Integer := HAC_Integer (Array_Entry.Element_Size);
+
+      Covered    : array (HAC_Integer range Lower_Bound .. Upper_Bound) of Boolean :=
+        (others => False);
+      Components : Default_Component_Vectors.Vector;
+
+      function Offset_Of (Array_Index : HAC_Integer) return HAC_Integer is
+        ((Array_Index - Lower_Bound) * Element_Size);
+
+      procedure Mark_Covered (Array_Index : HAC_Integer) is
+      begin
+        if Array_Index not in Lower_Bound .. Upper_Bound then
+          Error
+            (CD, err_choice_out_of_range,
+             "index" & HAC_Integer'Image (Array_Index) & " is out of the array's range, " &
+             HAC_Integer'Image (Lower_Bound) & " .." & HAC_Integer'Image (Upper_Bound),
+             severity => minor);
+        elsif Covered (Array_Index) then
+          Error (CD, err_aggregate_index_covered_twice, HAC_Integer'Image (Array_Index), severity => minor);
+        else
+          Covered (Array_Index) := True;
+        end if;
+      end Mark_Covered;
+
+      function Parse_One_Value return Default_Value_Access is
+      begin
+        if Element_Typ.TYP in Composite_Typ and then CD.Sy = LParent then
+          return Parse_Static_Composite_Value (Element_Typ);
+        elsif CD.Sy = IDent then
+          declare
+            Name : constant Alfa := CD.Id;
+          begin
+            In_Symbol;
+            return Resolve_Static_Direct_Name (Name);
+          end;
+        else
+          return Parse_Static_Scalar_Value (Element_Typ);
+        end if;
+      end Parse_One_Value;
+
+      --  Builds a literal value directly from an already-consumed (peeked)
+      --  literal token, without going through Parse_Static_Scalar_Value
+      --  (which expects to start parsing fresh at the current token).
+      function Literal_Value (Literal_Symbol : Symbol; Literal_Int : HAC_Integer) return Default_Value_Access is
+        Scalar_Typ : Exact_Subtyp;
+      begin
+        Scalar_Typ.Construct_Root (if Literal_Symbol = character_literal then Chars else Ints);
+        return new Default_Value'(Scalar_Default, Scalar_Typ, Literal_Int, 0.0);
+      end Literal_Value;
+
+      Next_Index : HAC_Integer := Lower_Bound;
+    begin
+      loop
+        if CD.Sy = OTHERS_Symbol then
+          In_Symbol;  --  Consume OTHERS_Symbol.
+          Need (CD, Finger, err_FINGER_missing);
+          declare
+            Fill : constant Default_Value_Access := Parse_One_Value;
+          begin
+            for Array_Index in Lower_Bound .. Upper_Bound loop
+              if not Covered (Array_Index) then
+                Components.Append ((Offset_Of (Array_Index), Fill));
+                Covered (Array_Index) := True;
+              end if;
+            end loop;
+          end;
+          exit;
+        elsif CD.Sy in integer_literal | character_literal then
+          declare
+            Peek_Symbol : constant Symbol     := CD.Sy;
+            Peek_Value  : constant HAC_Integer := CD.INum;
+          begin
+            In_Symbol;
+            if CD.Sy = Finger then
+              --  Named index choice: "Index => Value".
+              In_Symbol;  --  Consume '=>'.
+              Mark_Covered (Peek_Value);
+              Components.Append ((Offset_Of (Peek_Value), Parse_One_Value));
+            else
+              --  Positional: the peeked literal is this position's own value.
+              Components.Append ((Offset_Of (Next_Index), Literal_Value (Peek_Symbol, Peek_Value)));
+              Mark_Covered (Next_Index);
+              Next_Index := Next_Index + 1;
+            end if;
+          end;
+        else
+          Components.Append ((Offset_Of (Next_Index), Parse_One_Value));
+          Mark_Covered (Next_Index);
+          Next_Index := Next_Index + 1;
+        end if;
+        exit when CD.Sy /= Comma;
+        In_Symbol;  --  Consume ','.
+      end loop;
+      for Array_Index in Lower_Bound .. Upper_Bound loop
+        if not Covered (Array_Index) then
+          Error (CD, err_aggregate_index_not_covered, "", severity => minor);
+          exit;
+        end if;
+      end loop;
+      return new Default_Value'(Composite_Default, Components);
+    end Parse_Array_Default;
+
+    ------------------------------------------------------------------
+    --  Record defaults: "(Value, Value, ...)", "(Field => Value, ...)",
+    --  "(others => Value)". Unlike Aggregates' record parsing, a
+    --  positional component may not start with a bare identifier here
+    --  (documented v1 restriction: use named form, "Field => Some_Enum",
+    --  for a field whose static value is itself a bare identifier) --
+    --  this avoids re-implementing the field-name/value-identifier
+    --  disambiguation for a case that this feature's real use (literal
+    --  values) never needs.
+    ------------------------------------------------------------------
+    function Parse_Record_Default (Record_Expected : Exact_Subtyp) return Default_Value_Access is
+      Field_Count   : Natural := 0;
+      Counting_Walk : Integer := CD.Blocks_Table (Record_Expected.Ref).Last_Id_Idx;
+    begin
+      while Counting_Walk /= No_Id loop
+        Field_Count := Field_Count + 1;
+        Counting_Walk := Id_Table (Counting_Walk).link;
+      end loop;
+      if Field_Count = 0 then
+        return null;
+      end if;
+      declare
+        Fields        : array (1 .. Field_Count) of Integer;
+        Covered       : array (1 .. Field_Count) of Boolean := (others => False);
+        Building_Walk : Integer := CD.Blocks_Table (Record_Expected.Ref).Last_Id_Idx;
+        Components    : Default_Component_Vectors.Vector;
+        Next_Position : Positive := 1;
+
+        function Position_Of (Field_Id : Integer) return Natural is
+        begin
+          for Position in Fields'Range loop
+            if Fields (Position) = Field_Id then
+              return Position;
+            end if;
+          end loop;
+          return 0;
+        end Position_Of;
+
+        procedure Mark_Covered (Position : Natural) is
+        begin
+          if Position = 0 then
+            null;
+          elsif Covered (Position) then
+            Error
+              (CD, err_aggregate_field_covered_twice,
+               A2S (Id_Table (Fields (Position)).name_with_case), severity => minor);
+          else
+            Covered (Position) := True;
+          end if;
+        end Mark_Covered;
+
+        function Parse_One_Value (Field_Typ : Exact_Subtyp) return Default_Value_Access is
+        begin
+          if Field_Typ.TYP in Composite_Typ and then CD.Sy = LParent then
+            return Parse_Static_Composite_Value (Field_Typ);
+          elsif CD.Sy = IDent then
+            declare
+              Name : constant Alfa := CD.Id;
+            begin
+              In_Symbol;
+              return Resolve_Static_Direct_Name (Name);
+            end;
+          else
+            return Parse_Static_Scalar_Value (Field_Typ);
+          end if;
+        end Parse_One_Value;
+
+      begin
+        for Position in reverse Fields'Range loop
+          Fields (Position) := Building_Walk;
+          Building_Walk := Id_Table (Building_Walk).link;
+        end loop;
+
+        loop
+          if CD.Sy = OTHERS_Symbol then
+            In_Symbol;  --  Consume OTHERS_Symbol.
+            Need (CD, Finger, err_FINGER_missing);
+            declare
+              Common_Typ    : Exact_Subtyp;
+              Any_Uncovered : Boolean := False;
+              Types_Differ  : Boolean := False;
+            begin
+              for Position in Covered'Range loop
+                if not Covered (Position) then
+                  declare
+                    This_Typ : constant Exact_Subtyp := Id_Table (Fields (Position)).xtyp;
+                  begin
+                    if not Any_Uncovered then
+                      Common_Typ := This_Typ;
+                      Any_Uncovered := True;
+                    elsif Common_Typ.TYP /= This_Typ.TYP or else Common_Typ.Ref /= This_Typ.Ref then
+                      Types_Differ := True;
+                    end if;
+                  end;
+                end if;
+              end loop;
+              if Types_Differ then
+                Error (CD, err_aggregate_others_field_types_differ, severity => major);
+              end if;
+              if Any_Uncovered and then not Types_Differ then
+                declare
+                  Fill : constant Default_Value_Access := Parse_One_Value (Common_Typ);
+                begin
+                  for Position in Covered'Range loop
+                    if not Covered (Position) then
+                      Components.Append ((Id_Table (Fields (Position)).adr_or_sz, Fill));
+                      Covered (Position) := True;
+                    end if;
+                  end loop;
+                end;
+              else
+                declare
+                  Discard : Default_Value_Access;
+                  pragma Unreferenced (Discard);
+                begin
+                  Discard := Parse_One_Value (undefined_subtyp);
+                end;
+              end if;
+            end;
+            exit;
+          elsif CD.Sy = IDent then
+            declare
+              Peek_Name : constant Alfa := CD.Id;
+              Field_Id  : constant Integer :=
+                Locate_Record_Field (CD, Record_Expected.Ref, Peek_Name);
+            begin
+              In_Symbol;
+              if Field_Id = No_Id or else CD.Sy /= Finger then
+                Error
+                  (CD, err_default_value_must_be_static,
+                   "expected a field name (""Field => Value"") -- a positional " &
+                   "record-default component cannot start with a bare identifier",
+                   severity => major);
+                exit;
+              end if;
+              In_Symbol;  --  Consume '=>'.
+              Mark_Covered (Position_Of (Field_Id));
+              Components.Append
+                ((Id_Table (Field_Id).adr_or_sz,
+                  Parse_One_Value (Id_Table (Field_Id).xtyp)));
+              Next_Position := Position_Of (Field_Id) + 1;
+            end;
+          else
+            if Next_Position > Field_Count then
+              Error (CD, err_general_error, "too many components in default aggregate", severity => minor);
+              exit;
+            end if;
+            Components.Append
+              ((Id_Table (Fields (Next_Position)).adr_or_sz,
+                Parse_One_Value (Id_Table (Fields (Next_Position)).xtyp)));
+            Mark_Covered (Next_Position);
+            Next_Position := Next_Position + 1;
+          end if;
+          exit when CD.Sy /= Comma;
+          In_Symbol;  --  Consume ','.
+        end loop;
+        for Position in Covered'Range loop
+          if not Covered (Position) then
+            Error
+              (CD, err_aggregate_field_not_covered,
+               A2S (Id_Table (Fields (Position)).name_with_case), severity => minor);
+          end if;
+        end loop;
+        return new Default_Value'(Composite_Default, Components);
+      end;
+    end Parse_Record_Default;
+
+    function Parse_Static_Composite_Value
+      (Composite_Expected : Exact_Subtyp) return Default_Value_Access
+    is
+    begin
+      In_Symbol;  --  Consume '('.
+      declare
+        Result : constant Default_Value_Access :=
+          (case Composite_Typ (Composite_Expected.TYP) is
+             when Arrays  => Parse_Array_Default (Composite_Expected),
+             when Records => Parse_Record_Default (Composite_Expected));
+      begin
+        Need (CD, RParent, err_closing_parenthesis_missing);
+        return Result;
+      end;
+    end Parse_Static_Composite_Value;
+
+  begin
+    if Expected.TYP in Composite_Typ then
+      if CD.Sy /= LParent then
+        Error_then_Skip
+          (CD, FSys, err_default_value_must_be_static,
+           "a composite component's default must be an aggregate literal");
+        return null;
+      end if;
+      return Parse_Static_Composite_Value (Expected);
+    else
+      return Parse_Static_Scalar_Value (Expected);
+    end if;
+  end Parse_Static_Default_Value;
+
+  procedure Emit_Default_Value
+    (CD         : in out Co_Defs.Compiler_Data;
+     Dest_Level :        Defs.Nesting_Level;
+     Dest_Base  :        Defs.HAC_Integer;
+     Value      :        Co_Defs.Default_Value_Access)
+  is
+  begin
+    if Value = null then
+      return;
+    end if;
+    case Value.Kind is
+      when Scalar_Default =>
+        Emit_2 (CD, k_Push_Address, Operand_1_Type (Dest_Level), Operand_2_Type (Dest_Base));
+        if Value.Scalar_Typ.TYP = Floats then
+          Emit_Push_Float_Literal (CD, Value.Scalar_R);
+        else
+          CD.target.Emit_Push_Discrete_Literal (Value.Scalar_Int);
+        end if;
+        Emit_1 (CD, k_Store, Typen'Pos (Value.Scalar_Typ.TYP));
+      when Composite_Default =>
+        for Component of Value.Components loop
+          Emit_Default_Value (CD, Dest_Level, Dest_Base + Component.Offset, Component.Value);
+        end loop;
+    end case;
+  end Emit_Default_Value;
+
+  function Inherited_Default
+    (CD  : in out Co_Defs.Compiler_Data;
+     Typ :        Co_Defs.Exact_Subtyp) return Co_Defs.Default_Value_Access
+  is
+  begin
+    case Typ.TYP is
+      when Records =>
+        return CD.Blocks_Table (Typ.Ref).Default;
+      when Arrays =>
+        declare
+          Array_Entry     : Array_Table_Entry renames CD.Arrays_Table (Typ.Ref);
+          Element_Default : constant Default_Value_Access :=
+            Inherited_Default (CD, Array_Entry.Element_xTyp);
+        begin
+          if Element_Default = null then
+            return null;
+          end if;
+          declare
+            Lower_Bound  : constant HAC_Integer := Array_Entry.Index_xTyp.Discrete_First;
+            Upper_Bound  : constant HAC_Integer := Array_Entry.Index_xTyp.Discrete_Last;
+            Element_Size : constant HAC_Integer := HAC_Integer (Array_Entry.Element_Size);
+            Components   : Default_Component_Vectors.Vector;
+          begin
+            for Array_Index in Lower_Bound .. Upper_Bound loop
+              Components.Append
+                (((Array_Index - Lower_Bound) * Element_Size, Element_Default));
+            end loop;
+            return new Default_Value'(Composite_Default, Components);
+          end;
+        end;
+      when others =>
+        return null;
+    end case;
+  end Inherited_Default;
+
+end HAC_Sys.Parser.Defaults;

--- a/src/compile/hac_sys-parser-defaults.ads
+++ b/src/compile/hac_sys-parser-defaults.ads
@@ -1,0 +1,67 @@
+-------------------------------------------------------------------------------------
+--
+--  HAC - HAC Ada Compiler
+--
+--  A compiler in Ada for an Ada subset
+--
+--  Copyright, license, etc. : see top package.
+--
+-------------------------------------------------------------------------------------
+--
+--  Record component default values (RM 3.7 / 3.8 default_expression),
+--  restricted to *static* values: literals, named numbers, enumeration
+--  literals, and aggregates built from these. Because everything here
+--  resolves to a compile-time-known value rather than code to replay, a
+--  field's default is computed once (when its record type is declared)
+--  and stored as plain data (Co_Defs.Default_Value); it is then stamped
+--  out as ordinary Push_Address + literal + Store code at every later
+--  object declaration that has no explicit initializer -- safe at any
+--  lexical level, since nothing here is captured bytecode.
+--
+--  Not supported (documented v1 restriction): default expressions that
+--  reference functions or variables (would require threading flow-analysis
+--  context through the whole type-declaration call chain, for a feature
+--  whose only real-world need is static values); a composite field's
+--  default naming another composite constant instead of an aggregate
+--  literal; box notation "<>".
+
+private package HAC_Sys.Parser.Defaults is
+
+  --  Parses one field's default value. Precondition: ":=" already
+  --  consumed; CD.Sy is positioned at the start of the value. Consumes
+  --  through the end of the value (a static scalar expression, or a
+  --  parenthesized static aggregate, positional/named/"others", when
+  --  Expected is a record or array type).
+  --
+  function Parse_Static_Default_Value
+    (CD       : in out Co_Defs.Compiler_Data;
+     Level    :        Defs.Nesting_Level;
+     FSys     :        Defs.Symset;
+     Expected :        Co_Defs.Exact_Subtyp) return Co_Defs.Default_Value_Access;
+
+  --  Emits store code for Value (as built by Parse_Static_Default_Value,
+  --  or inherited/fanned-out from a nested type's own Default) at
+  --  (Dest_Level, Dest_Base), recursively.
+  --
+  procedure Emit_Default_Value
+    (CD         : in out Co_Defs.Compiler_Data;
+     Dest_Level :        Defs.Nesting_Level;
+     Dest_Base  :        Defs.HAC_Integer;
+     Value      :        Co_Defs.Default_Value_Access);
+
+  --  For a field with no explicit default, returns whatever default it
+  --  should inherit from its own type, or null if there is none:
+  --  a Records type contributes its own stored whole-type Default; an
+  --  Arrays type recursively fans its element type's own inherited
+  --  default out across every position (handling array-of-array-of-...
+  --  -record uniformly, since HAC represents multi-dimensional arrays
+  --  as arrays of arrays); any other type contributes null (arrays and
+  --  scalars never carry a default of their own -- RM 3.7/3.8 only ever
+  --  attaches default_expression to an object declaration or a record
+  --  component declaration, never to a type declaration itself).
+  --
+  function Inherited_Default
+    (CD  : in out Co_Defs.Compiler_Data;
+     Typ :        Co_Defs.Exact_Subtyp) return Co_Defs.Default_Value_Access;
+
+end HAC_Sys.Parser.Defaults;

--- a/src/compile/hac_sys-parser-expressions.adb
+++ b/src/compile/hac_sys-parser-expressions.adb
@@ -97,27 +97,25 @@ package body HAC_Sys.Parser.Expressions is
   is
 
     procedure Record_Field_Selector is
-      Field_Offset, Field_Id : Integer;
-      use type Alfa;
+      Field_Offset : Integer;
     begin
       if V.TYP = Records then
-        Field_Id := CD.Blocks_Table (V.Ref).Last_Id_Idx;
-        CD.id_table (0).name := CD.Id;
-        while CD.id_table (Field_Id).name /= CD.Id loop  --  Search field identifier
-          Field_Id := CD.id_table (Field_Id).link;
-        end loop;
-        if Field_Id = No_Id then
-          Error (CD, err_undefined_identifier, A2S (CD.Id_with_case), severity => major);
-        else
-          CD.target.Mark_Reference (Field_Id);
-          CD.id_table (Field_Id).is_referenced := True;
-          Elevate_to_Maybe (CD.id_table (Field_Id).is_read);
-          V := CD.id_table (Field_Id).xtyp;
-          Field_Offset := Integer (CD.id_table (Field_Id).adr_or_sz);
-          if Field_Offset /= 0 then
-            Emit_1 (CD, k_Record_Field_Offset, Operand_2_Type (Field_Offset));
+        declare
+          Field_Id : constant Integer := Locate_Record_Field (CD, V.Ref, CD.Id);
+        begin
+          if Field_Id = No_Id then
+            Error (CD, err_undefined_identifier, A2S (CD.Id_with_case), severity => major);
+          else
+            CD.target.Mark_Reference (Field_Id);
+            CD.id_table (Field_Id).is_referenced := True;
+            Elevate_to_Maybe (CD.id_table (Field_Id).is_read);
+            V := CD.id_table (Field_Id).xtyp;
+            Field_Offset := Integer (CD.id_table (Field_Id).adr_or_sz);
+            if Field_Offset /= 0 then
+              Emit_1 (CD, k_Record_Field_Offset, Operand_2_Type (Field_Offset));
+            end if;
           end if;
-        end if;
+        end;
       else
         Error (CD, err_var_with_field_selector_must_be_record);
       end if;

--- a/src/compile/hac_sys-parser-helpers.adb
+++ b/src/compile/hac_sys-parser-helpers.adb
@@ -10,6 +10,7 @@
 --
 
 with HAC_Sys.Compiler.PCode_Emit,
+     HAC_Sys.Parser.Ranges,
      HAC_Sys.PCode,
      HAC_Sys.Scanner,
      HAC_Sys.Errors;
@@ -1033,5 +1034,133 @@ package body HAC_Sys.Parser.Helpers is
            block.Last_Param_Id_Idx - block.First_Param_Id_Idx + 1);
     end;
   end Number_of_Parameters;
+
+  function Locate_Record_Field
+    (CD         : in out Compiler_Data;
+     Record_Ref : in     Index;
+     Field_Name : in     Alfa)
+  return Integer
+  is
+    --  Local view of Compiler_Data's identifier table so this function can
+    --  spell it "Id_Table" (GNAT's identifier-reference style check
+    --  requires every reference to match its own declaration's casing --
+    --  this is a fresh, locally declared name, free to have its own).
+    Id_Table : Identifier_Table_Type renames CD.id_table;
+    Field_Id : Integer := CD.Blocks_Table (Record_Ref).Last_Id_Idx;
+    use type Alfa;
+  begin
+    while Field_Id /= No_Id and then Id_Table (Field_Id).name /= Field_Name loop
+      Field_Id := Id_Table (Field_Id).link;
+    end loop;
+    return Field_Id;
+  end Locate_Record_Field;
+
+  procedure Emit_Type_Checked_Store_or_Copy
+    (CD           : in out Compiler_Data;
+     Expected_Typ : in     Exact_Subtyp;
+     Found_Typ    : in     Exact_Subtyp)
+  is
+    use Compiler.PCode_Emit, PCode;
+    Array_Length : Natural;
+    procedure Issue_Type_Mismatch_Error is
+    begin
+      Type_Mismatch
+        (CD, err_types_of_assignment_must_match, Found => Found_Typ, Expected => Expected_Typ);
+    end Issue_Type_Mismatch_Error;
+  begin
+    if Expected_Typ.TYP = Found_Typ.TYP and Expected_Typ.TYP /= NOTYP then
+      if Discrete_Typ (Expected_Typ.TYP) then
+        if Ranges.Do_Ranges_Overlap (Expected_Typ, Found_Typ) then
+          if Expected_Typ.Discrete_First > Found_Typ.Discrete_First then
+            Compiler.PCode_Emit.Emit_3
+              (CD, k_Check_Lower_Bound, Expected_Typ.Discrete_First,
+               Typen'Pos (Expected_Typ.TYP), Operand_3_Type (Expected_Typ.Ref));
+          end if;
+          if Expected_Typ.Discrete_Last < Found_Typ.Discrete_Last then
+            Compiler.PCode_Emit.Emit_3
+              (CD, k_Check_Upper_Bound, Expected_Typ.Discrete_Last,
+               Typen'Pos (Expected_Typ.TYP), Operand_3_Type (Expected_Typ.Ref));
+          end if;
+        else
+          Error
+            (CD, err_range_constraint_error,
+             "value of expression (" &
+             (if Ranges.Is_Singleton_Range (Found_Typ) then
+                --  More understandable message part for a single value
+                Discrete_Image (CD, Found_Typ.Discrete_First, Expected_Typ.TYP, Expected_Typ.Ref)
+              else
+                "range: " &
+                Discrete_Range_Image
+                  (CD, Found_Typ.Discrete_First, Found_Typ.Discrete_Last,
+                   Expected_Typ.TYP, Expected_Typ.Ref)) &
+             ") is out of destination's range, " &
+             Discrete_Range_Image
+               (CD, Expected_Typ.Discrete_First, Expected_Typ.Discrete_Last,
+                Expected_Typ.TYP, Expected_Typ.Ref),
+             severity => minor);
+        end if;
+      end if;
+      if Expected_Typ.TYP in Standard_Typ then
+        Emit_1 (CD, k_Store, Typen'Pos (Expected_Typ.TYP));
+      elsif Expected_Typ.Ref /= Found_Typ.Ref then
+        Issue_Type_Mismatch_Error;  --  E.g. different arrays, enums, ...
+      else
+        case Expected_Typ.TYP is
+          when Arrays =>
+            Emit_1 (CD, k_Copy_Block, Operand_2_Type (CD.Arrays_Table (Expected_Typ.Ref).Array_Size));
+          when Records =>
+            Emit_1 (CD, k_Copy_Block, Operand_2_Type (CD.Blocks_Table (Expected_Typ.Ref).VSize));
+          when Enums =>
+            --  Behaves like a "Standard_Typ".
+            --  We have checked that Expected_Typ.Ref = Found_Typ.Ref (same actual type).
+            Emit_1 (CD, k_Store, Typen'Pos (Expected_Typ.TYP));
+          when others =>
+            raise Internal_error with "Emit_Type_Checked_Store_or_Copy: unsupported Typ ?";
+        end case;
+      end if;
+    else
+      --
+      --  Here, Expected_Typ.TYP and Found_Typ.TYP are different.
+      --
+      if Expected_Typ.TYP = Floats and Found_Typ.TYP = Ints then
+        Forbid_Type_Coercion (CD, Found => Found_Typ, Expected => Expected_Typ);
+      elsif Expected_Typ.TYP = Durations and Found_Typ.TYP = Floats then
+        --  Duration hack (see Delay_Statement for full explanation).
+        Emit_Std_Funct (CD, SF_Float_to_Duration);
+        Emit_1 (CD, k_Store, Typen'Pos (Expected_Typ.TYP));
+      elsif Is_Char_Array (CD, Expected_Typ) and Found_Typ.TYP = String_Literals then
+        Array_Length := CD.Arrays_Table (Expected_Typ.Ref).Array_Size;
+        if Array_Length = CD.SLeng then
+          Emit_1 (CD, k_String_Literal_Assignment, Operand_2_Type (Array_Length));
+        else
+          Error (CD, err_string_lengths_do_not_match,
+            "variable has length" & Integer'Image (Array_Length) &
+            ", literal has length" & Integer'Image (CD.SLeng),
+            severity => minor);
+        end if;
+      elsif Expected_Typ.TYP = VStrings
+        and then
+          (Found_Typ.TYP in String_Literals | Strings_as_VStrings
+           or else Is_Char_Array (CD, Found_Typ))
+      then
+        Error (CD, err_string_to_vstring_assignment);
+      elsif Expected_Typ.TYP = NOTYP then
+        if CD.error_count = 0 then
+          raise Internal_error with
+            "Emit_Type_Checked_Store_or_Copy: assigned variable (Expected_Typ) is typeless";
+        end if;
+        --  All right, there were already enough compilation error messages...
+      elsif Found_Typ.TYP = NOTYP then
+        if CD.error_count = 0 then
+          raise Internal_error with
+            "Emit_Type_Checked_Store_or_Copy: assigned value (Found_Typ) is typeless";
+        end if;
+        --  All right, there were already enough compilation error messages...
+      else
+        Issue_Type_Mismatch_Error;
+        --  NB: We are in the Expected_Typ.TYP /= Found_Typ.TYP case.
+      end if;
+    end if;
+  end Emit_Type_Checked_Store_or_Copy;
 
 end HAC_Sys.Parser.Helpers;

--- a/src/compile/hac_sys-parser-helpers.ads
+++ b/src/compile/hac_sys-parser-helpers.ads
@@ -421,4 +421,28 @@ package HAC_Sys.Parser.Helpers is
      id_idx     : in     Natural)
   return Natural;
 
+  --  Search a record type's own field list (scoped to that record's block,
+  --  not the general identifier scope) for a field named Field_Name.
+  --  Returns the field's id_table index, or No_Id if there is no such field.
+  --
+  function Locate_Record_Field
+    (CD         : in out Compiler_Data;
+     Record_Ref : in     Index;
+     Field_Name : in     Alfa)
+  return Integer;
+
+  --  Given a destination's expected type and the type of a value already
+  --  produced on the stack (Found_Typ, from an Expression or from
+  --  Aggregates), do the full assignment-compatibility check (range checks,
+  --  type coercion rules, string/VString special cases) and emit either
+  --  k_Store (scalar/enum) or k_Copy_Block (composite). This is exactly the
+  --  tail of plain assignment (Statements.Assignment), factored out here so
+  --  that Aggregates can reuse it, without creating a circular dependency
+  --  between Statements and Aggregates.
+  --
+  procedure Emit_Type_Checked_Store_or_Copy
+    (CD           : in out Compiler_Data;
+     Expected_Typ : in     Exact_Subtyp;
+     Found_Typ    : in     Exact_Subtyp);
+
 end HAC_Sys.Parser.Helpers;

--- a/src/compile/hac_sys-parser-statements.adb
+++ b/src/compile/hac_sys-parser-statements.adb
@@ -1,4 +1,5 @@
 with HAC_Sys.Compiler.PCode_Emit,
+     HAC_Sys.Parser.Aggregates,
      HAC_Sys.Parser.Calls,
      HAC_Sys.Parser.Enter_Def,
      HAC_Sys.Parser.Expressions,
@@ -17,23 +18,17 @@ package body HAC_Sys.Parser.Statements is
   procedure Assignment
     (CD                : in out Co_Defs.Compiler_Data;
      FSys              :        Defs.Symset;
-     context           :        Defs.Flow_Context;
+     Block_Data        : in out Block_Data_Type;
      var_id_index      :        Integer;
      check_is_variable :        Boolean)
   is
     use Compiler.PCode_Emit, Co_Defs, Defs, Expressions, Helpers, PCode, Scanner, Errors;
     var : Identifier_Table_Entry renames CD.id_table (var_id_index);
-    X, Y  : Exact_Subtyp;
-    X_Len : Natural;
-    --
-    procedure Issue_Type_Mismatch_Error is
-    begin
-      Type_Mismatch (CD, err_types_of_assignment_must_match, Found => Y, Expected => X);
-    end Issue_Type_Mismatch_Error;
-    --
+    Expected_Typ, Found_Typ : Exact_Subtyp;
+    Has_Selector : Boolean;
   begin
     pragma Assert (var.entity in Object_Kind);
-    X := var.xtyp;
+    Expected_Typ := var.xtyp;
     Emit_2
      (CD,
       (if var.normal then
@@ -42,10 +37,11 @@ package body HAC_Sys.Parser.Statements is
          k_Push_Discrete_Value),  --  The value is a reference, we want that address.
       Operand_1_Type (var.lev),
       Operand_2_Type (var.adr_or_sz));
-    if Selector_Symbol_Loose (CD.Sy) then  --  '.' or '(' or (wrongly) '['
+    Has_Selector := Selector_Symbol_Loose (CD.Sy);  --  '.' or '(' or (wrongly) '['
+    if Has_Selector then
       --  Resolve composite types' selectors (arrays and records).
-      Selector (CD, context, Becomes_EQL + FSys, X);
-      --  Now, X denotes the leaf type (which can be composite as well).
+      Selector (CD, Block_Data.context, Becomes_EQL + FSys, Expected_Typ);
+      --  Now, Expected_Typ denotes the leaf type (which can be composite as well).
     end if;
     --  Parse the  ":="  of  "X := Y;"
     case CD.Sy is
@@ -63,92 +59,59 @@ package body HAC_Sys.Parser.Statements is
       Error (CD, err_cannot_modify_constant_or_in_parameter);
     end if;
 
-    Expression (CD, context, Semicolon_Set, Y);
-    --
-    if X.TYP = Y.TYP and X.TYP /= NOTYP then
-      if Discrete_Typ (X.TYP) then
-        if Ranges.Do_Ranges_Overlap (X, Y) then
-          if X.Discrete_First > Y.Discrete_First then
-            Compiler.PCode_Emit.Emit_3
-              (CD, k_Check_Lower_Bound, X.Discrete_First, Typen'Pos (X.TYP), Operand_3_Type (X.Ref));
-          end if;
-          if X.Discrete_Last < Y.Discrete_Last then
-            Compiler.PCode_Emit.Emit_3
-              (CD, k_Check_Upper_Bound, X.Discrete_Last, Typen'Pos (X.TYP), Operand_3_Type (X.Ref));
-          end if;
-        else
-          Error
-            (CD, err_range_constraint_error,
-             "value of expression (" &
-             (if Ranges.Is_Singleton_Range (Y) then
-                --  More understandable message part for a single value
-                Discrete_Image (CD, Y.Discrete_First, X.TYP, X.Ref)
-              else
-                "range: " &
-                Discrete_Range_Image (CD, Y.Discrete_First, Y.Discrete_Last, X.TYP, X.Ref)) &
-             ") is out of destination's range, " &
-             Discrete_Range_Image (CD, X.Discrete_First, X.Discrete_Last, X.TYP, X.Ref),
-             severity => minor);
-        end if;
-      end if;
-      if X.TYP in Standard_Typ then
-        Emit_1 (CD, k_Store, Typen'Pos (X.TYP));
-      elsif X.Ref /= Y.Ref then
-        Issue_Type_Mismatch_Error;  --  E.g. different arrays, enums, ...
+    if Expected_Typ.TYP in Composite_Typ and then CD.Sy = LParent then
+      --  Aggregate RHS: "X := (...);" or "X.Field := (...);" or "X (i) := (...);".
+      if Has_Selector or else not var.normal then
+        --  The destination's address is already on the stack, pushed above
+        --  (and, if there is a selector chain, further adjusted by Selector)
+        --  -- leave it there. This covers two cases where Aggregates cannot
+        --  simply compute "var.lev / var.adr_or_sz + compile-time offset"
+        --  directly: a selector chain that may involve a runtime-computed
+        --  offset (e.g. a dynamic array index), and a by-reference variable
+        --  (an "out"/"in out" composite parameter, whose adr_or_sz holds a
+        --  pointer that must be read at run time via k_Push_Discrete_Value,
+        --  not treated as a compile-time base address). In both cases,
+        --  materialize the aggregate into a fresh compiler-generated
+        --  temporary of the same composite type (this does not disturb the
+        --  stack: each component's codegen is stack-neutral), then push the
+        --  temp's address as the source and copy it as a whole onto the
+        --  real (possibly dynamic or by-reference) destination.
+        declare
+          Temp_Size : constant Integer :=
+            (case Composite_Typ (Expected_Typ.TYP) is
+               when Arrays  => CD.Arrays_Table (Expected_Typ.Ref).Array_Size,
+               when Records => CD.Blocks_Table (Expected_Typ.Ref).VSize);
+          Temp_Level : constant Nesting_Level := Block_Data.context.level;
+          Temp_Base  : constant HAC_Integer   := HAC_Integer (Block_Data.data_allocation_index);
+        begin
+          Block_Data.data_allocation_index := Block_Data.data_allocation_index + Temp_Size;
+          Block_Data.max_data_allocation_index :=
+            Integer'Max (Block_Data.max_data_allocation_index, Block_Data.data_allocation_index);
+          CD.Blocks_Table (CD.Display (Block_Data.context.level)).VSize :=
+            Block_Data.max_data_allocation_index;
+          Aggregates.Parse_Aggregate (CD, Block_Data, FSys, Expected_Typ, Temp_Level, Temp_Base);
+          --  Do *not* decrement Block_Data.data_allocation_index back down:
+          --  HAC_Sys.Parser.Block's Declarative_Part re-derives each block's
+          --  VSize from data_allocation_index (not the high-water mark
+          --  max_data_allocation_index) after every declaration, so
+          --  releasing the temp here would let that later reset silently
+          --  shrink VSize back below what the temp needs, leaving its
+          --  memory outside the block's reserved stack region. Leaving the
+          --  slot permanently reserved for the rest of the block costs a
+          --  few extra words of stack, not a correctness problem.
+          Emit_2 (CD, k_Push_Address, Operand_1_Type (Temp_Level), Operand_2_Type (Temp_Base));
+          Emit_1 (CD, k_Copy_Block, Operand_2_Type (Temp_Size));
+        end;
       else
-        case X.TYP is
-          when Arrays =>
-            Emit_1 (CD, k_Copy_Block, Operand_2_Type (CD.Arrays_Table (X.Ref).Array_Size));
-          when Records =>
-            Emit_1 (CD, k_Copy_Block, Operand_2_Type (CD.Blocks_Table (X.Ref).VSize));
-          when Enums =>
-            --  Behaves like a "Standard_Typ".
-            --  We have checked that X.Ref = Y.Ref (same actual type).
-            Emit_1 (CD, k_Store, Typen'Pos (X.TYP));
-          when others =>
-            raise Internal_error with "Assignment: X := Y on unsupported Typ ?";
-        end case;
+        --  Bare destination: var.lev / var.adr_or_sz are compile-time
+        --  constants. Discard the now-unused single address pushed above;
+        --  Aggregates emits its own per-component addresses directly.
+        Emit (CD, k_Pop);
+        Aggregates.Parse_Aggregate (CD, Block_Data, FSys, Expected_Typ, var.lev, var.adr_or_sz);
       end if;
     else
-      --
-      --  Here, X.TYP and Y.TYP are different.
-      --
-      if X.TYP = Floats and Y.TYP = Ints then
-        Forbid_Type_Coercion (CD, Found => Y, Expected => X);
-      elsif X.TYP = Durations and Y.TYP = Floats then
-        --  Duration hack (see Delay_Statement for full explanation).
-        Emit_Std_Funct (CD, SF_Float_to_Duration);
-        Emit_1 (CD, k_Store, Typen'Pos (X.TYP));
-      elsif Is_Char_Array (CD, X) and Y.TYP = String_Literals then
-        X_Len := CD.Arrays_Table (X.Ref).Array_Size;
-        if X_Len = CD.SLeng then
-          Emit_1 (CD, k_String_Literal_Assignment, Operand_2_Type (X_Len));
-        else
-          Error (CD, err_string_lengths_do_not_match,
-            "variable has length" & Integer'Image (X_Len) &
-            ", literal has length" & Integer'Image (CD.SLeng),
-            severity => minor);
-        end if;
-      elsif X.TYP = VStrings
-        and then
-          (Y.TYP in String_Literals | Strings_as_VStrings
-           or else Is_Char_Array (CD, Y))
-      then
-        Error (CD, err_string_to_vstring_assignment);
-      elsif X.TYP = NOTYP then
-        if CD.error_count = 0 then
-          raise Internal_error with "Assignment: assigned variable (X) is typeless";
-        end if;
-        --  All right, there were already enough compilation error messages...
-      elsif Y.TYP = NOTYP then
-        if CD.error_count = 0 then
-          raise Internal_error with "Assignment: assigned value (Y) is typeless";
-        end if;
-        --  All right, there were already enough compilation error messages...
-      else
-        Issue_Type_Mismatch_Error;
-        --  NB: We are in the X.TYP /= Y.TYP case.
-      end if;
+      Expression (CD, Block_Data.context, Semicolon_Set, Found_Typ);
+      Emit_Type_Checked_Store_or_Copy (CD, Expected_Typ, Found_Typ);
     end if;
   end Assignment;
 
@@ -963,7 +926,7 @@ package body HAC_Sys.Parser.Statements is
       else
         case CD.id_table (I_Statement).entity is
           when Object_Kind =>
-            Assignment (CD, FSys_St, block_data.context, I_Statement, check_is_variable => True);
+            Assignment (CD, FSys_St, block_data, I_Statement, check_is_variable => True);
             Elevate_to_Maybe_or_Yes
               (CD.id_table (I_Statement).is_written_after_init, block_data.context);
 

--- a/src/compile/hac_sys-parser-statements.ads
+++ b/src/compile/hac_sys-parser-statements.ads
@@ -14,7 +14,7 @@ private package HAC_Sys.Parser.Statements is
   procedure Assignment
     (CD                : in out Co_Defs.Compiler_Data;
      FSys              :        Defs.Symset;
-     context           :        Defs.Flow_Context;
+     Block_Data        : in out Block_Data_Type;
      var_id_index      :        Integer;
      check_is_variable :        Boolean);
 

--- a/src/compile/hac_sys-parser-type_def.adb
+++ b/src/compile/hac_sys-parser-type_def.adb
@@ -9,7 +9,8 @@
 -------------------------------------------------------------------------------------
 --
 
-with HAC_Sys.Parser.Enter_Def,
+with HAC_Sys.Parser.Defaults,
+     HAC_Sys.Parser.Enter_Def,
      HAC_Sys.Parser.Helpers,
      HAC_Sys.Parser.Ranges,
      HAC_Sys.Scanner,
@@ -191,7 +192,8 @@ package body HAC_Sys.Parser.Type_Def is
 
     procedure Record_Typ is  --  RM 3.8
       Field_Exact_Subtyp : Exact_Subtyp;
-      Field_Size, Offset, T0, T1 : Integer;
+      Field_Size, Offset, T0, T1, Group_First : Integer;
+      Local_Defaults : Default_Component_Vectors.Vector;
     begin
       In_Symbol;  --  Consume RECORD symbol.
       Enter_Block (CD, CD.Id_Count);
@@ -211,18 +213,22 @@ package body HAC_Sys.Parser.Type_Def is
           Enter_Variables (CD, Level, False);
           Need (CD, Colon, err_colon_missing);  --  ':'  in  "a, b, c : Integer;"
           T1 := CD.Id_Count;
+          Group_First := T0;
           if Type_Begin_Symbol (CD.Sy) then
             Error (CD, err_general_error, "anonymous definition not permitted here");
             --  Recovery:
             Type_Definition
-              (CD, Level, FSys_TD + Comma_END_IDent_Semicolon,
+              (CD, Level, FSys_TD + Comma_END_IDent_Semicolon + Becomes_Set,
                Field_Exact_Subtyp, Field_Size);
           else
             --  RM 3.6 (2)
             --  Here is a component_definition, which is a
-            --  subtype indication (possibly aliased).
+            --  subtype indication (possibly aliased). Becomes_Set is
+            --  included in the follow set so that an optional RM 3.7/3.8
+            --  default_expression ("... := Value") is accepted here rather
+            --  than rejected as an unexpected symbol -- see below.
             Subtype_Indication
-              (CD, Level, FSys_TD + Comma_END_IDent_Semicolon,
+              (CD, Level, FSys_TD + Comma_END_IDent_Semicolon + Becomes_Set,
                Field_Exact_Subtyp, Field_Size);
           end if;
           while T0 < T1 loop
@@ -231,6 +237,27 @@ package body HAC_Sys.Parser.Type_Def is
             CD.id_table (T0).adr_or_sz := HAC_Integer (Offset);
             Offset                  := Offset + Field_Size;
           end loop;
+          --  RM 3.7 / 3.8: an optional default_expression (restricted to
+          --  static values -- see HAC_Sys.Parser.Defaults), or, absent
+          --  that, whatever default this field's own type already carries
+          --  (record-in-record or array-of-record/array nesting).
+          declare
+            Field_Default : Default_Value_Access;
+          begin
+            if CD.Sy = Becomes then
+              Scanner.In_Symbol (CD);  --  Consume ':='.
+              Field_Default :=
+                Defaults.Parse_Static_Default_Value
+                  (CD, Level, FSys_TD + Comma_END_IDent_Semicolon, Field_Exact_Subtyp);
+            else
+              Field_Default := Defaults.Inherited_Default (CD, Field_Exact_Subtyp);
+            end if;
+            if Field_Default /= null then
+              for Name_Idx in Group_First + 1 .. T1 loop
+                Local_Defaults.Append ((CD.id_table (Name_Idx).adr_or_sz, Field_Default));
+              end loop;
+            end if;
+          end;
         else
           Error (CD, err_identifier_missing, severity => major);
         end if;
@@ -241,6 +268,9 @@ package body HAC_Sys.Parser.Type_Def is
       CD.Blocks_Table (xTP.Ref).VSize := Offset;
       Size                            := Offset;
       CD.Blocks_Table (xTP.Ref).PSize := 0;
+      CD.Blocks_Table (xTP.Ref).Default :=
+        (if Local_Defaults.Is_Empty then null
+         else new Default_Value'(Composite_Default, Local_Defaults));
       In_Symbol;
       Need (CD, RECORD_Symbol, err_RECORD_missing);  --  (END) RECORD
       Level := Level - 1;

--- a/test/aggregates.adb
+++ b/test/aggregates.adb
@@ -1,0 +1,380 @@
+--  Test aggregates (RM 4.3): array and record aggregates used as object
+--  declaration initializers and in plain assignment statements.
+
+with HAT;
+with Testing_Utilities;
+
+procedure Aggregates is
+  use HAT, Testing_Utilities;
+
+  procedure Positional_Array is
+    type Arr is array (1 .. 3) of Integer;
+    a : Arr := (1, 2, 3);
+  begin
+    Assert (a (1) = 1 and a (2) = 2 and a (3) = 3, +"Compiler bug [Positional_Array]");
+  end Positional_Array;
+
+  procedure Named_Array_With_Others is
+    type Arr is array (1 .. 5) of Integer;
+    a : Arr := (1 => 10, 3 => 30, others => 0);
+  begin
+    Assert (
+      a (1) = 10 and a (2) = 0 and a (3) = 30 and a (4) = 0 and a (5) = 0,
+      +"Compiler bug [Named_Array_With_Others]"
+    );
+  end Named_Array_With_Others;
+
+  procedure Multidimensional_Array_With_Others is
+    --  A true multi-dimensional array (RM 3.6.1 comma syntax, one array
+    --  type with 2 dimensions, not an array-of-arrays) whose "others" fill
+    --  value is itself a nested aggregate for the inner dimension, not a
+    --  scalar literal -- exercises the materialize-into-temp-then-copy
+    --  path for array "others", not just the static-literal fast path.
+    type Vector_2 is array (1 .. 3, 1 .. 2) of Integer;
+    All_Others  : Vector_2 := (others => (others => 2));
+    Row_1_Then_Others : Vector_2 := (1 => (9, 9), others => (others => 0));
+  begin
+    Assert (
+      All_Others (1, 1) = 2 and All_Others (1, 2) = 2 and
+      All_Others (2, 1) = 2 and All_Others (2, 2) = 2 and
+      All_Others (3, 1) = 2 and All_Others (3, 2) = 2,
+      +"Compiler bug [Multidimensional_Array_With_Others/All_Others]"
+    );
+    Assert (
+      Row_1_Then_Others (1, 1) = 9 and Row_1_Then_Others (1, 2) = 9 and
+      Row_1_Then_Others (2, 1) = 0 and Row_1_Then_Others (2, 2) = 0 and
+      Row_1_Then_Others (3, 1) = 0 and Row_1_Then_Others (3, 2) = 0,
+      +"Compiler bug [Multidimensional_Array_With_Others/Row_1_Then_Others]"
+    );
+  end Multidimensional_Array_With_Others;
+
+  procedure Positional_Record is
+    type Rec is record
+      i : Integer;
+      r : Real;
+      b : Boolean;
+    end record;
+    x : Rec := (1, 2.0, True);
+  begin
+    Assert (x.i = 1 and x.r = 2.0 and x.b, +"Compiler bug [Positional_Record]");
+  end Positional_Record;
+
+  procedure Named_Record is
+    type Rec is record
+      i : Integer;
+      r : Real;
+    end record;
+    x : Rec := (r => 3.0, i => 7);  --  Named, out of declaration order.
+  begin
+    Assert (x.i = 7 and x.r = 3.0, +"Compiler bug [Named_Record]");
+  end Named_Record;
+
+  procedure Variable_And_Function_Values is
+    --  Aggregate component values need not be literals: variable/constant
+    --  references and function calls must work in every position -- array
+    --  positional and named-choice values, record named-field values, and
+    --  record positional values (both the first component and later ones,
+    --  since the first component's disambiguation logic is separate code
+    --  from the later-component path).
+    function Double (N : Integer) return Integer is
+    begin
+      return N * 2;
+    end Double;
+
+    X : constant Integer := 5;
+    Y : constant Integer := 10;
+
+    type Arr is array (1 .. 3) of Integer;
+    type Rec is record
+      A, B, C : Integer;
+    end record;
+
+    Arr_Positional : constant Arr := (X, Double (X), Y);
+    Arr_Named      : constant Arr := (1 => X, 2 => Double (X), 3 => Y);
+    Rec_Named      : constant Rec := (A => X, B => Double (X), C => Y);
+    Rec_Pos_First_Var  : constant Rec := (X, 2, 3);
+    Rec_Pos_First_Func : constant Rec := (Double (X), 2, 3);
+    Rec_Pos_Later_Var  : constant Rec := (1, X, 3);
+    Rec_Pos_Later_Func : constant Rec := (1, Double (X), 3);
+  begin
+    Assert (
+      Arr_Positional (1) = 5 and Arr_Positional (2) = 10 and Arr_Positional (3) = 10,
+      +"Compiler bug [Variable_And_Function_Values/Arr_Positional]"
+    );
+    Assert (
+      Arr_Named (1) = 5 and Arr_Named (2) = 10 and Arr_Named (3) = 10,
+      +"Compiler bug [Variable_And_Function_Values/Arr_Named]"
+    );
+    Assert (
+      Rec_Named.A = 5 and Rec_Named.B = 10 and Rec_Named.C = 10,
+      +"Compiler bug [Variable_And_Function_Values/Rec_Named]"
+    );
+    Assert (
+      Rec_Pos_First_Var.A = 5 and Rec_Pos_First_Var.B = 2 and Rec_Pos_First_Var.C = 3,
+      +"Compiler bug [Variable_And_Function_Values/Rec_Pos_First_Var]"
+    );
+    Assert (
+      Rec_Pos_First_Func.A = 10 and Rec_Pos_First_Func.B = 2 and Rec_Pos_First_Func.C = 3,
+      +"Compiler bug [Variable_And_Function_Values/Rec_Pos_First_Func]"
+    );
+    Assert (
+      Rec_Pos_Later_Var.A = 1 and Rec_Pos_Later_Var.B = 5 and Rec_Pos_Later_Var.C = 3,
+      +"Compiler bug [Variable_And_Function_Values/Rec_Pos_Later_Var]"
+    );
+    Assert (
+      Rec_Pos_Later_Func.A = 1 and Rec_Pos_Later_Func.B = 10 and Rec_Pos_Later_Func.C = 3,
+      +"Compiler bug [Variable_And_Function_Values/Rec_Pos_Later_Func]"
+    );
+  end Variable_And_Function_Values;
+
+  procedure Nested_Array_of_Arrays is
+    type Inner is array (1 .. 2) of Integer;
+    type Outer is array (1 .. 2) of Inner;
+    a : Outer := ((1, 2), (3, 4));
+  begin
+    Assert (
+      a (1) (1) = 1 and a (1) (2) = 2 and a (2) (1) = 3 and a (2) (2) = 4,
+      +"Compiler bug [Nested_Array_of_Arrays]"
+    );
+  end Nested_Array_of_Arrays;
+
+  procedure Record_with_Array_Field is
+    type Arr is array (1 .. 2) of Integer;
+    type Rec is record
+      tag  : Integer;
+      vals : Arr;
+    end record;
+    x : Rec := (tag => 1, vals => (10, 20));
+  begin
+    Assert (
+      x.tag = 1 and x.vals (1) = 10 and x.vals (2) = 20,
+      +"Compiler bug [Record_with_Array_Field]"
+    );
+  end Record_with_Array_Field;
+
+  procedure Assignment_Form is
+    --  Aggregates used in a plain assignment statement, not just a declaration.
+    type Arr is array (1 .. 3) of Integer;
+    a : Arr;
+  begin
+    a := (7, 8, 9);
+    Assert (a (1) = 7 and a (2) = 8 and a (3) = 9, +"Compiler bug [Assignment_Form]");
+  end Assignment_Form;
+
+  procedure Selector_Qualified_Destination is
+    --  Aggregate assigned to a field, reached via a selector (not a bare
+    --  variable) -- exercises the temp-then-Copy_Block fallback path.
+    type Arr is array (1 .. 2) of Integer;
+    type Rec is record
+      f : Arr;
+    end record;
+    r : Rec;
+  begin
+    r.f := (11, 22);
+    Assert (r.f (1) = 11 and r.f (2) = 22, +"Compiler bug [Selector_Qualified_Destination]");
+  end Selector_Qualified_Destination;
+
+  procedure By_Reference_Parameter_Destination is
+    --  Aggregate assigned to a bare "out"/"in out" composite parameter
+    --  (passed by reference) -- exercises the temp-then-Copy_Block fallback
+    --  path via a runtime-held reference, not a compile-time address.
+    type Arr is array (1 .. 3) of Integer;
+    type Rec is record f1, f2 : Integer; end record;
+
+    procedure Make (Result : out Arr) is
+    begin
+      Result := (1, 2, 3);
+    end Make;
+
+    procedure Reset (R : in out Rec) is
+    begin
+      R := (10, 20);
+    end Reset;
+
+    a : Arr;
+    r : Rec := (1, 2);
+  begin
+    Make (a);
+    Reset (r);
+    Assert (
+      a (1) = 1 and a (2) = 2 and a (3) = 3 and r.f1 = 10 and r.f2 = 20,
+      +"Compiler bug [By_Reference_Parameter_Destination]"
+    );
+  end By_Reference_Parameter_Destination;
+
+  procedure Positional_Then_Others is
+    --  The common "some explicit values, then others" idiom: positional
+    --  components followed by a trailing "others" association.
+    type Arr is array (1 .. 5) of Integer;
+    a : Arr := (1, 2, others => 0);
+  begin
+    Assert (
+      a (1) = 1 and a (2) = 2 and a (3) = 0 and a (4) = 0 and a (5) = 0,
+      +"Compiler bug [Positional_Then_Others]"
+    );
+  end Positional_Then_Others;
+
+  procedure Record_Others is
+    --  "others" for records: allowed when every field it covers shares the
+    --  same type (RM 4.3.1). Exercises the materialize-into-temp-then-fan-
+    --  out-copy mechanism, including when the fill value is itself a
+    --  nested aggregate, and nested "others" at multiple levels.
+    type Point_2D is record
+      X, Y : Integer;
+    end record;
+    type Box is record
+      Upper, Lower : Point_2D;
+    end record;
+
+    Sole      : Point_2D := (others => 42);
+    Mixed     : Box := (Upper => (1, 2), others => (3, 4));
+    All_Same  : Box := (others => (4, 5));
+    Doubly    : Box := (others => (others => 0));
+    Positional_With_Inner_Others : Box := ((1, 2), (others => 4));
+    Named_Reordered : Box := (Lower => (others => 7), Upper => (8, 9));
+  begin
+    Assert (Sole.X = 42 and Sole.Y = 42, +"Compiler bug [Record_Others/Sole]");
+    Assert (
+      Mixed.Upper.X = 1 and Mixed.Upper.Y = 2 and Mixed.Lower.X = 3 and Mixed.Lower.Y = 4,
+      +"Compiler bug [Record_Others/Mixed]"
+    );
+    Assert (
+      All_Same.Upper.X = 4 and All_Same.Upper.Y = 5 and
+      All_Same.Lower.X = 4 and All_Same.Lower.Y = 5,
+      +"Compiler bug [Record_Others/All_Same]"
+    );
+    Assert (
+      Doubly.Upper.X = 0 and Doubly.Upper.Y = 0 and Doubly.Lower.X = 0 and Doubly.Lower.Y = 0,
+      +"Compiler bug [Record_Others/Doubly]"
+    );
+    Assert (
+      Positional_With_Inner_Others.Upper.X = 1 and Positional_With_Inner_Others.Upper.Y = 2 and
+      Positional_With_Inner_Others.Lower.X = 4 and Positional_With_Inner_Others.Lower.Y = 4,
+      +"Compiler bug [Record_Others/Positional_With_Inner_Others]"
+    );
+    Assert (
+      Named_Reordered.Upper.X = 8 and Named_Reordered.Upper.Y = 9 and
+      Named_Reordered.Lower.X = 7 and Named_Reordered.Lower.Y = 7,
+      +"Compiler bug [Record_Others/Named_Reordered]"
+    );
+  end Record_Others;
+
+  procedure Others_Evaluated_Once_Per_Position is
+    --  RM 4.3.3 (5): the "others" expression must be evaluated once *per
+    --  component it covers*, not once total. A true 2D array (array-of-
+    --  arrays internally), fully filled via nested "others" at both
+    --  dimensions, with a side-effecting fill function -- this is the
+    --  exact shape that used to silently copy one evaluation's result to
+    --  every position instead of calling the function again for each one.
+    type Vector_2 is array (1 .. 2, 1 .. 2) of Integer;
+    Counter : Integer := 0;
+    function New_Number return Integer is
+    begin
+      Counter := Counter + 1;
+      return Counter;
+    end New_Number;
+    V : Vector_2 := (others => (others => New_Number));
+  begin
+    Assert (
+      V (1, 1) = 1 and V (1, 2) = 2 and V (2, 1) = 3 and V (2, 2) = 4,
+      +"Compiler bug [Others_Evaluated_Once_Per_Position]"
+    );
+  end Others_Evaluated_Once_Per_Position;
+
+  procedure Others_With_Mixed_Nested_Fields is
+    --  A composite (record) fill value that mixes an ordinary named
+    --  component with a side-effecting one, itself nested under an
+    --  array's "others" -- exercises that *every* leaf of a captured
+    --  fill value (not just a top-level scalar) is independently
+    --  replayed once per position, including ordinary (non-"others")
+    --  fields of a nested aggregate literal.
+    type Pair is record
+      A, B : Integer;
+    end record;
+    type Pair_Array is array (1 .. 2) of Pair;
+    Counter : Integer := 100;
+    function Next return Integer is
+    begin
+      Counter := Counter + 1;
+      return Counter;
+    end Next;
+    PA : Pair_Array := (others => (A => 1, B => Next));
+  begin
+    Assert (
+      PA (1).A = 1 and PA (1).B = 101 and PA (2).A = 1 and PA (2).B = 102,
+      +"Compiler bug [Others_With_Mixed_Nested_Fields]"
+    );
+  end Others_With_Mixed_Nested_Fields;
+
+  procedure Plain_Parenthesized_Still_Works is
+    --  Regression: "(X)" as a plain parenthesized expression (not an
+    --  aggregate) must be unaffected by aggregate support.
+    type Arr is array (1 .. 2) of Integer;
+    src : Arr := (5, 6);
+    dst : Arr := (src);
+  begin
+    Assert (dst (1) = 5 and dst (2) = 6, +"Compiler bug [Plain_Parenthesized_Still_Works]");
+  end Plain_Parenthesized_Still_Works;
+
+begin
+  Positional_Array;
+  Named_Array_With_Others;
+  Multidimensional_Array_With_Others;
+  Positional_Record;
+  Named_Record;
+  Variable_And_Function_Values;
+  Nested_Array_of_Arrays;
+  Record_with_Array_Field;
+  Assignment_Form;
+  Selector_Qualified_Destination;
+  By_Reference_Parameter_Destination;
+  Positional_Then_Others;
+  Record_Others;
+  Others_Evaluated_Once_Per_Position;
+  Others_With_Mixed_Nested_Fields;
+  Plain_Parenthesized_Still_Works;
+  --
+  --  Intentionally-invalid forms (left as comments per project convention,
+  --  see test/exception_01.adb, test/optim.adb):
+  --
+  --  declare
+  --    type Rec is record i, j : Integer; end record;
+  --    x : Rec := (1, 2, 3);  --  Compile-time error: too many components.
+  --  begin null; end;
+  --
+  --  declare
+  --    type Arr is array (1 .. 3) of Integer;
+  --    a : Arr := (1, 2);  --  Compile-time error: err_aggregate_index_not_covered.
+  --  begin null; end;
+  --
+  --  declare
+  --    type Arr is array (1 .. 3) of Integer;
+  --    a : Arr := (1 => 1, 1 => 2, others => 0);  --  Compile-time error:
+  --                                                --  err_aggregate_index_covered_twice.
+  --  begin null; end;
+  --
+  --  declare
+  --    type Rec is record i, j : Integer; end record;
+  --    x : Rec := (i => 1);  --  Compile-time error: err_aggregate_field_not_covered ("j").
+  --  begin null; end;
+  --
+  --  declare
+  --    type Arr is array (1 .. 3) of Integer;
+  --    a : Arr := (others => 0, 1 => 5);  --  Compile-time error:
+  --                                       --  err_aggregate_others_not_last.
+  --  begin null; end;
+  --
+  --  declare
+  --    type Rec is record i, j : Integer; end record;
+  --    x : Rec := (1, j => 2);  --  Compile-time error:
+  --                            --  err_aggregate_positional_after_named ("j"
+  --                            --  cannot be named after "1" was positional).
+  --  begin null; end;
+  --
+  --  declare
+  --    type Rec is record I : Integer; B : Boolean; end record;
+  --    x : Rec := (others => 5);  --  Compile-time error:
+  --                              --  err_aggregate_others_field_types_differ
+  --                              --  (I and B do not have the same type).
+  --  begin null; end;
+end Aggregates;

--- a/test/all_silent_tests.adb
+++ b/test/all_silent_tests.adb
@@ -141,6 +141,7 @@ procedure All_Silent_Tests is
     Put_Line ("  One instance of HAC is called each time, with compilation and execution...");
     New_Line;
     Put_Line (+"    Normal tests in " & Current_Directory & ':');
+    Normal_Test (+"aggregates.adb");
     Normal_Test (+"attributes_test.adb");
     Normal_Test (examples_dir & "barnes.adb 3816547290");
     Normal_Test (+"case_statement.adb");
@@ -157,6 +158,7 @@ procedure All_Silent_Tests is
     Normal_Test (+"-I. .." & Directory_Separator & "exm" & Directory_Separator & "pkg_demo.adb test_mode");
     Shell_Execute (generate & " delete");
     --
+    Normal_Test (+"record_defaults.adb");
     Normal_Test (+"recursion.adb");
     Normal_Test (+"remarks_check.adb");
     Normal_Test (+"sorting_tests.adb");

--- a/test/hac_test.gpr
+++ b/test/hac_test.gpr
@@ -21,6 +21,7 @@ project HAC_Test is
      "all_silent_tests.adb",
      "silent_tests_single_build.adb",
      --
+     "aggregates.adb",
      "attributes_test.adb",
      "case_statement.adb",
      "constants.adb",
@@ -37,6 +38,7 @@ project HAC_Test is
      "integers.adb",
      "loops.adb",
      "object_init.adb",
+     "record_defaults.adb",
      "recursion.adb",
      "sorting_tests.adb",
      "strings.adb",

--- a/test/record_defaults.adb
+++ b/test/record_defaults.adb
@@ -1,0 +1,134 @@
+--  Test record component default values (RM 3.7 / 3.8 default_expression),
+--  restricted to static values, and their automatic application to any
+--  object declared without an explicit initializer (recursively, through
+--  nested records and arrays of records).
+
+with HAT;
+with Testing_Utilities;
+
+procedure Record_Defaults is
+  use HAT, Testing_Utilities;
+
+  procedure Scalar_Field_Defaults is
+    type Point_2D is record
+      X : Integer := 0;
+      Y : Integer := 0;
+    end record;
+    P : Point_2D;  --  No initializer -- becomes (0, 0).
+  begin
+    Assert (P.X = 0 and P.Y = 0, +"Compiler bug [Scalar_Field_Defaults]");
+  end Scalar_Field_Defaults;
+
+  procedure Composite_Field_Default_And_Inheritance is
+    --  The user's own example: a field with its own aggregate default
+    --  (Upper), and a field with no own default that falls back to its
+    --  type's own defaults (Lower).
+    type Point_2D is record
+      X : Integer := 0;
+      Y : Integer := 0;
+    end record;
+    type Box is record
+      Upper : Point_2D := (1, 1);
+      Lower : Point_2D;
+    end record;
+    B : Box;
+  begin
+    Assert (
+      B.Upper.X = 1 and B.Upper.Y = 1 and B.Lower.X = 0 and B.Lower.Y = 0,
+      +"Compiler bug [Composite_Field_Default_And_Inheritance]"
+    );
+  end Composite_Field_Default_And_Inheritance;
+
+  procedure Array_Of_Record_Inheritance is
+    --  A whole array-typed variable, with no initializer, whose element
+    --  type is a record with defaults -- every element must independently
+    --  get that record type's own default (RM 3.3.1: default
+    --  initialization applies to every subcomponent at any depth,
+    --  including through array indexing).
+    type Point_2D is record
+      X : Integer := 5;
+      Y : Integer := 7;
+    end record;
+    type Point_Array is array (1 .. 3) of Point_2D;
+    PA : Point_Array;
+  begin
+    Assert (
+      PA (1).X = 5 and PA (1).Y = 7 and
+      PA (2).X = 5 and PA (2).Y = 7 and
+      PA (3).X = 5 and PA (3).Y = 7,
+      +"Compiler bug [Array_Of_Record_Inheritance]"
+    );
+  end Array_Of_Record_Inheritance;
+
+  procedure Partial_Defaults is
+    --  Some fields defaulted, some not -- the undefaulted ones must remain
+    --  ordinary (explicitly assignable/readable) variables, unaffected by
+    --  the defaulting mechanism.
+    type Point_2D is record
+      X : Integer := 5;
+      Y : Integer := 7;
+    end record;
+    type Mixed is record
+      A : Integer;         --  No default: ordinary field.
+      B : Point_2D := (1, 2);
+      C : Point_2D;         --  Inherits (5, 7).
+    end record;
+    M : Mixed;
+  begin
+    M.A := 42;  --  Undefaulted field: must still work like any variable.
+    Assert (
+      M.A = 42 and M.B.X = 1 and M.B.Y = 2 and M.C.X = 5 and M.C.Y = 7,
+      +"Compiler bug [Partial_Defaults]"
+    );
+  end Partial_Defaults;
+
+  procedure No_Defaults_Still_Works is
+    --  Regression: a record type with no defaults at all must compile and
+    --  behave exactly as before this feature existed.
+    type Point_2D is record
+      X, Y : Integer;
+    end record;
+    P : Point_2D;
+  begin
+    P.X := 3;
+    P.Y := 4;
+    Assert (P.X = 3 and P.Y = 4, +"Compiler bug [No_Defaults_Still_Works]");
+  end No_Defaults_Still_Works;
+
+  procedure Explicit_Initializer_Overrides_Default is
+    --  An explicit initializer on the object declaration itself must take
+    --  priority over -- not be overwritten by -- the type's own defaults.
+    type Point_2D is record
+      X : Integer := 0;
+      Y : Integer := 0;
+    end record;
+    P : Point_2D := (9, 9);
+  begin
+    Assert (P.X = 9 and P.Y = 9, +"Compiler bug [Explicit_Initializer_Overrides_Default]");
+  end Explicit_Initializer_Overrides_Default;
+
+  procedure Multiple_Names_Share_Default is
+    --  "A, B : Point_2D;" (no initializer): both must independently get
+    --  the same default, at their own distinct addresses.
+    type Point_2D is record
+      X : Integer := 1;
+      Y : Integer := 2;
+    end record;
+    A, B : Point_2D;
+  begin
+    A.X := 100;  --  Must not affect B.
+    Assert (
+      A.X = 100 and A.Y = 2 and B.X = 1 and B.Y = 2,
+      +"Compiler bug [Multiple_Names_Share_Default]"
+    );
+  end Multiple_Names_Share_Default;
+
+begin
+  Scalar_Field_Defaults;
+  Composite_Field_Default_And_Inheritance;
+  Array_Of_Record_Inheritance;
+  Partial_Defaults;
+  No_Defaults_Still_Works;
+  Explicit_Initializer_Overrides_Default;
+  Multiple_Names_Share_Default;
+end Record_Defaults;


### PR DESCRIPTION
Added support for aggregates (including nested ones) and record field default values (static values only).

Now it is possible to initialize objects or update their values using aggregates expressions. Aggregates can also use a mixture of positional or named associations. 

Record fields can have default values specified in their type declaration. The default values themselves can even be aggregates.

Several test cases were added to verify this new functionality.

All code was generated using Claude AI.